### PR TITLE
Fix Python Dependencies

### DIFF
--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,10 +1,10 @@
-black==23.11.0
-flake8==6.1.0
-mypy==1.7.1
-pytest==7.4.3
-pytest-asyncio==0.23.2
-pytest-cov==4.1.0
+black==24.10.0
+flake8==7.1.0
+mypy==1.13.0
+pytest==8.3.3
+pytest-asyncio==0.24.0
+pytest-cov==6.0.0
 
 types-python-jose==3.3.4.8
 
-uvicorn[standard]==0.23.2
+uvicorn[standard]==0.32.0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,13 +1,10 @@
-fastapi==0.104.1
-httpx==0.25.2
-python-multipart==0.0.5
+fastapi==0.115.5
+httpx==0.27.2
+python-multipart==0.0.12
 python3-saml==1.16.0
 python-jose[cryptography]==3.3.0
-motor==3.3.2
-pydantic[email]==2.5.2
+motor==3.6.0
+pydantic[email]==2.9.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
-aiogoogle==5.6.0
-
-# To avoid breaking xmlsec for python3-saml
-lxml<5.0.0
+aiogoogle==5.13.2

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,10 +1,10 @@
-fastapi==0.115.5
+fastapi==0.113.0
 httpx==0.27.2
-python-multipart==0.0.12
+python-multipart==0.0.17
 python3-saml==1.16.0
 python-jose[cryptography]==3.3.0
 motor==3.6.0
 pydantic[email]==2.9.2
 aiosendgrid==0.1.0
 sendgrid==6.11.0
-aiogoogle==5.13.2
+aiogoogle==5.6.0

--- a/apps/api/tests/test_guest_auth.py
+++ b/apps/api/tests/test_guest_auth.py
@@ -41,8 +41,8 @@ def test_can_validate_key() -> None:
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
 async def test_get_existing_unexpired_key(mock_mongodb_retrieve_one: AsyncMock) -> None:
     """Test that existing, unexpired guest authorization key can be retrieved."""
-    iat = datetime(2023, 1, 11)
-    exp = datetime(2024, 7, 1, tzinfo=timezone.utc)
+    iat = datetime(2024, 1, 11)
+    exp = datetime(2025, 7, 1, tzinfo=timezone.utc)  # update expire date for this test to not fail :)
     # this test will fail next year :P
     mock_mongodb_retrieve_one.return_value = {
         "guest_auth": {"iat": iat, "exp": exp, "key": "some-key"}

--- a/apps/api/tests/test_guest_auth.py
+++ b/apps/api/tests/test_guest_auth.py
@@ -42,7 +42,9 @@ def test_can_validate_key() -> None:
 async def test_get_existing_unexpired_key(mock_mongodb_retrieve_one: AsyncMock) -> None:
     """Test that existing, unexpired guest authorization key can be retrieved."""
     iat = datetime(2024, 1, 11)
-    exp = datetime(2025, 7, 1, tzinfo=timezone.utc)  # update expire date for this test to not fail :)
+    exp = datetime(
+        2025, 7, 1, tzinfo=timezone.utc
+    )  # update expire date for this test to not fail :)
     # this test will fail next year :P
     mock_mongodb_retrieve_one.return_value = {
         "guest_auth": {"iat": iat, "exp": exp, "key": "some-key"}

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -14,7 +14,7 @@ from utils import resume_handler
 from utils.user_record import Applicant, Status
 
 # Tests will break again next year, tech should notice and fix :P
-TEST_DEADLINE = datetime(2024, 10, 1, 8, 0, 0, tzinfo=timezone.utc)
+TEST_DEADLINE = datetime(2025, 10, 1, 8, 0, 0, tzinfo=timezone.utc)
 user.DEADLINE = TEST_DEADLINE
 
 USER_EMAIL = "pkfire@uci.edu"
@@ -49,7 +49,7 @@ EMPTY_RESUME = ("", b"", "application/octet-stream")
 
 EXPECTED_RESUME_UPLOAD = ("pk-fire-69f2afc2.pdf", b"resume", "application/pdf")
 SAMPLE_RESUME_URL = HttpUrl("https://drive.google.com/file/d/...")
-SAMPLE_SUBMISSION_TIME = datetime(2023, 1, 12, 8, 1, 21, tzinfo=timezone.utc)
+SAMPLE_SUBMISSION_TIME = datetime(2024, 1, 12, 8, 1, 21, tzinfo=timezone.utc)
 SAMPLE_VERDICT_TIME = None
 
 EXPECTED_APPLICATION_DATA = ProcessedApplicationData(
@@ -88,6 +88,7 @@ client = UserTestClient(USER_PKFIRE, app)
 
 @patch("utils.email_handler.send_application_confirmation_email", autospec=True)
 @patch("services.mongodb_handler.update_one", autospec=True)
+@patch("routers.user._is_past_deadline", autospec=True)
 @patch("routers.user.datetime", autospec=True)
 @patch("services.gdrive_handler.upload_file", autospec=True)
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
@@ -95,6 +96,7 @@ def test_apply_successfully(
     mock_mongodb_handler_retrieve_one: AsyncMock,
     mock_gdrive_handler_upload_file: AsyncMock,
     mock_datetime: Mock,
+    mock_is_past_deadline: Mock,
     mock_mongodb_handler_update_one: AsyncMock,
     mock_send_application_confirmation_email: AsyncMock,
 ) -> None:
@@ -102,6 +104,7 @@ def test_apply_successfully(
     mock_mongodb_handler_retrieve_one.return_value = None
     mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
     mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
+    mock_is_past_deadline.return_value = False
     res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
 
     mock_gdrive_handler_upload_file.assert_awaited_once_with(


### PR DESCRIPTION
- The main purpose of this PR is to update the Python Motor package to version 3.6.0 to resolve pymongo compatibility issues after the release of pymongo 4.9.X
- Also updates the other Python packages
- Updates FastAPI to `0.113.0`

Note:
- With FastAPI `>0.113.0` the test_apply_successfully_without_resume pytest fails because the `/apply` route doesn't seem to like being passed an empty resume file with file name as an empty string `""` for the resume parameter. This is seemingly caused by the resume parameter being declared of type `Optional[UploadFile]` and with FastAPI versions `>0.113.0`, the empty resume files being sent is seen as of type `str`. Will attempt to take a look at this in another issue.