### PR TITLE
Update/constrain database query for user identity

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -43,6 +43,7 @@ jobs:
           workdir: apps/api
           level: warning
           reporter: github-pr-review
+          filter_mode: nofilter
 
       - name: Lint with flake8
         uses: reviewdog/action-flake8@v3
@@ -50,6 +51,7 @@ jobs:
           workdir: apps/api
           level: warning
           reporter: github-pr-review
+          filter_mode: nofilter
 
       - name: Cache `.mypy_cache`
         uses: actions/cache@v3
@@ -58,12 +60,13 @@ jobs:
           key: ${{ runner.os }}-python3.9-mypy-cache
 
       - name: Lint with mypy (review)
-        uses: tsuyoshicho/action-mypy@v4
+        uses: tsuyoshicho/action-mypy@v5
         if: github.event_name == 'pull_request'
         with:
           workdir: apps/api
           level: error
           reporter: github-pr-review
+          filter_mode: nofilter
 
       - name: Run mypy (check)
         uses: tsuyoshicho/action-mypy@v4
@@ -106,6 +109,7 @@ jobs:
         with:
           level: warning
           reporter: github-pr-review
+          filter_mode: nofilter
           prettier_flags: apps/site/src
 
       - name: Lint with ESLint (review)
@@ -114,6 +118,7 @@ jobs:
         with:
           level: error
           reporter: github-pr-review
+          filter_mode: nofilter
           eslint_flags: apps/site/src
 
       - name: Lint with ESLint (check)

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -67,7 +67,7 @@ async def me(
     if not user:
         return dict()
     user_record = await mongodb_handler.retrieve_one(
-        Collection.USERS, {"_id": user.uid}
+        Collection.USERS, {"_id": user.uid}, ["role", "status"]
     )
     if not user_record:
         return {"uid": user.uid}

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -65,7 +65,7 @@ async def me(
 ) -> IdentityResponse:
     log.info(user)
     if not user:
-        return dict()
+        return IdentityResponse()
     user_record = await mongodb_handler.retrieve_one(
         Collection.USERS, {"_id": user.uid}, ["role", "status"]
     )

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -59,10 +59,10 @@ async def logout() -> RedirectResponse:
     return response
 
 
-@router.get("/me", response_model=IdentityResponse)
+@router.get("/me")
 async def me(
     user: Annotated[Union[User, None], Depends(use_user_identity)]
-) -> dict[str, object]:
+) -> IdentityResponse:
     log.info(user)
     if not user:
         return dict()
@@ -70,8 +70,10 @@ async def me(
         Collection.USERS, {"_id": user.uid}, ["role", "status"]
     )
     if not user_record:
-        return {"uid": user.uid}
-    return {**user_record, "uid": user.uid}
+        return IdentityResponse(uid=user.uid)
+    return IdentityResponse(
+        uid=user.uid, role=user_record.role, status=user_record.status
+    )
 
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -69,7 +69,7 @@ async def me(
     user_record = await mongodb_handler.retrieve_one(
         Collection.USERS, {"_id": user.uid}, ["role", "status"]
     )
-    
+
     if not user_record:
         return IdentityResponse(uid=user.uid)
 

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -69,11 +69,11 @@ async def me(
     user_record = await mongodb_handler.retrieve_one(
         Collection.USERS, {"_id": user.uid}, ["role", "status"]
     )
+    
     if not user_record:
         return IdentityResponse(uid=user.uid)
-    return IdentityResponse(
-        uid=user.uid, role=user_record.role, status=user_record.status
-    )
+
+    return IdentityResponse(uid=user.uid, **user_record)
 
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -140,7 +140,7 @@ def test_user_with_status_accepted_un_rsvp_returns_403(
 def test_user_me_route_returns_correct_type(
     mock_mongodb_handler_retrieve_one: AsyncMock,
 ) -> None:
-    """Test user with WAIVER_SIGNED status has new status of CONFIRMED after RSVP."""
+    """Test user me route returns correct fields as listed in user.IdentityResponse"""
     mock_mongodb_handler_retrieve_one.return_value = {
         "status": Status.WAIVER_SIGNED,
         "role": Role.VOLUNTEER,

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -56,7 +56,7 @@ def test_plain_identity_when_no_user_record(
     res = client.get("/me")
 
     mock_mongodb_handler_retrieve_one.assert_awaited_once_with(
-        Collection.USERS, {"_id": "edu.stanford.tree"}
+        Collection.USERS, {"_id": "edu.stanford.tree"}, ["role", "status"]
     )
     data = res.json()
     assert data == {"uid": "edu.stanford.tree", "status": None, "role": None}


### PR DESCRIPTION
Closes #402 

- Added query projection to `mongodb_handler.retrieve_one` call in `/me` route
- Replaced FastAPI `response_model` with explicit `IdentityResponse`  
- Added test to check that `IdentityResponse` fields are returned from `/me` route