### PR TITLE
Restructure user record to have multiple roles

### DIFF
--- a/apps/api/src/admin/summary_handler.py
+++ b/apps/api/src/admin/summary_handler.py
@@ -15,7 +15,7 @@ async def applicant_summary() -> Counter[ApplicantStatus]:
     """Get summary of applicants by status."""
     records = await mongodb_handler.retrieve(
         Collection.USERS,
-        {"role": Role.APPLICANT},
+        {"roles": Role.APPLICANT},
         ["status"],
     )
     applicants = TypeAdapter(list[ApplicantSummaryRecord]).validate_python(records)

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -23,10 +23,10 @@ log = getLogger(__name__)
 
 router = APIRouter()
 
-ADMIN_ROLES = (Role.DIRECTOR, Role.REVIEWER, Role.CHECKIN_LEAD)
-ORGANIZER_ROLES = (Role.ORGANIZER,)
-
-require_checkin_associate = require_role(ADMIN_ROLES + ORGANIZER_ROLES)
+require_manager = require_role({Role.DIRECTOR, Role.REVIEWER, Role.CHECKIN_LEAD})
+require_checkin_lead = require_role({Role.DIRECTOR, Role.CHECKIN_LEAD})
+require_director = require_role({Role.DIRECTOR})
+require_organizer = require_role({Role.ORGANIZER})
 
 
 class ApplicationDataSummary(BaseModel):
@@ -45,14 +45,14 @@ class ApplicantSummary(BaseRecord):
 
 @router.get("/applicants")
 async def applicants(
-    user: User = Depends(require_role(ADMIN_ROLES)),
+    user: Annotated[User, Depends(require_manager)]
 ) -> list[ApplicantSummary]:
     """Get records of all applicants."""
     log.info("%s requested applicants", user)
 
     records: list[dict[str, object]] = await mongodb_handler.retrieve(
         Collection.USERS,
-        {"role": Role.APPLICANT},
+        {"roles": Role.APPLICANT},
         [
             "_id",
             "status",
@@ -73,13 +73,13 @@ async def applicants(
         raise RuntimeError("Could not parse applicant data.")
 
 
-@router.get("/applicant/{uid}", dependencies=[Depends(require_role(ADMIN_ROLES))])
+@router.get("/applicant/{uid}", dependencies=[Depends(require_manager)])
 async def applicant(
     uid: str,
 ) -> Applicant:
     """Get record of an applicant by uid."""
     record: Optional[dict[str, object]] = await mongodb_handler.retrieve_one(
-        Collection.USERS, {"_id": uid, "role": Role.APPLICANT}
+        Collection.USERS, {"_id": uid, "roles": Role.APPLICANT}
     )
 
     if not record:
@@ -91,10 +91,7 @@ async def applicant(
         raise RuntimeError("Could not parse applicant data.")
 
 
-@router.get(
-    "/summary/applicants",
-    dependencies=[Depends(require_role(ADMIN_ROLES))],
-)
+@router.get("/summary/applicants", dependencies=[Depends(require_manager)])
 async def applicant_summary() -> dict[ApplicantStatus, int]:
     """Provide summary of statuses of applicants."""
     return await summary_handler.applicant_summary()
@@ -104,7 +101,7 @@ async def applicant_summary() -> dict[ApplicantStatus, int]:
 async def submit_review(
     applicant: str = Body(),
     decision: Decision = Body(),
-    reviewer: User = Depends(require_role([Role.REVIEWER])),
+    reviewer: User = Depends(require_role({Role.REVIEWER})),
 ) -> None:
     """Submit a review decision from the reviewer for the given applicant."""
     log.info("%s reviewed applicant %s", reviewer, applicant)
@@ -125,7 +122,7 @@ async def submit_review(
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@router.post("/release", dependencies=[Depends(require_role([Role.DIRECTOR]))])
+@router.post("/release", dependencies=[Depends(require_director)])
 async def release_decisions() -> None:
     """Update applicant status based on decision and send decision emails."""
     records = await mongodb_handler.retrieve(
@@ -146,7 +143,7 @@ async def release_decisions() -> None:
         )
 
 
-@router.post("/rsvp-reminder", dependencies=[Depends(require_role([Role.DIRECTOR]))])
+@router.post("/rsvp-reminder", dependencies=[Depends(require_director)])
 async def rsvp_reminder() -> None:
     """Send email to applicants who have a status of ACCEPTED or WAIVER_SIGNED
     reminding them to RSVP."""
@@ -154,7 +151,7 @@ async def rsvp_reminder() -> None:
     not_yet_rsvpd: list[dict[str, Any]] = await mongodb_handler.retrieve(
         Collection.USERS,
         {
-            "role": Role.APPLICANT,
+            "roles": Role.APPLICANT,
             "status": {"$in": [Decision.ACCEPTED, Status.WAIVER_SIGNED]},
         },
         ["_id", "first_name"],
@@ -180,16 +177,12 @@ async def rsvp_reminder() -> None:
     )
 
 
-@router.post(
-    "/confirm-attendance", dependencies=[Depends(require_role([Role.DIRECTOR]))]
-)
+@router.post("/confirm-attendance", dependencies=[Depends(require_director)])
 async def confirm_attendance() -> None:
     """Update applicant status to void or attending based on their current status."""
     # TODO: consider using Pydantic model, maybe BareApplicant
     records = await mongodb_handler.retrieve(
-        Collection.USERS,
-        {"role": Role.APPLICANT},
-        ["_id", "status"],
+        Collection.USERS, {"roles": Role.APPLICANT}, ["_id", "status"]
     )
 
     statuses = {
@@ -218,15 +211,15 @@ async def confirm_attendance() -> None:
         )
 
 
-@router.post(
-    "/waitlist-release/{uid}",
-    dependencies=[Depends(require_role([Role.DIRECTOR, Role.CHECKIN_LEAD]))],
-)
-async def waitlist_release(uid: str) -> None:
+@router.post("/waitlist-release/{uid}")
+async def waitlist_release(
+    uid: str,
+    associate: Annotated[User, Depends(require_checkin_lead)],
+) -> None:
     """Release an applicant from the waitlist and send email."""
     record = await mongodb_handler.retrieve_one(
         Collection.USERS,
-        {"_id": uid, "role": Role.APPLICANT, "status": Decision.WAITLISTED},
+        {"_id": uid, "roles": Role.APPLICANT, "status": Decision.WAITLISTED},
         ["status", "first_name"],
     )
     if not record:
@@ -238,14 +231,13 @@ async def waitlist_release(uid: str) -> None:
     if not ok:
         raise RuntimeError("gg wp")
 
+    log.info("%s accepted %s off the waitlist. Sending email.", associate, uid)
     await email_handler.send_waitlist_release_email(
         record["first_name"], _recover_email_from_uid(uid)
     )
 
-    log.info(f"Accepted {uid} off the waitlist and sent email.")
 
-
-@router.get("/participants", dependencies=[Depends(require_checkin_associate)])
+@router.get("/participants", dependencies=[Depends(require_organizer)])
 async def participants() -> list[Participant]:
     """Get list of participants."""
     # TODO: consider combining the two functions into one
@@ -258,7 +250,7 @@ async def participants() -> list[Participant]:
 async def check_in_participant(
     uid: str,
     badge_number: Annotated[str, Body()],
-    associate: Annotated[User, Depends(require_checkin_associate)],
+    associate: Annotated[User, Depends(require_organizer)],
 ) -> None:
     """Check in participant at IrvineHacks."""
     try:
@@ -276,7 +268,7 @@ async def check_in_participant(
 async def update_attendance(
     uid: str,
     director: Annotated[
-        User, Depends(require_role([Role.DIRECTOR, Role.CHECKIN_LEAD]))
+        User, Depends(require_role({Role.DIRECTOR, Role.CHECKIN_LEAD}))
     ],
 ) -> None:
     """Update status to Role.ATTENDING for non-hackers."""
@@ -289,7 +281,7 @@ async def update_attendance(
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-@router.get("/events", dependencies=[Depends(require_checkin_associate)])
+@router.get("/events", dependencies=[Depends(require_organizer)])
 async def events() -> list[dict[str, object]]:
     """Get list of events"""
     return await mongodb_handler.retrieve(Collection.EVENTS, {})
@@ -299,7 +291,7 @@ async def events() -> list[dict[str, object]]:
 async def subevent_checkin(
     event: str,
     uid: Annotated[str, Body()],
-    organizer: Annotated[User, Depends(require_checkin_associate)],
+    organizer: Annotated[User, Depends(require_organizer)],
 ) -> None:
     await participant_manager.subevent_checkin(event, uid, organizer)
 

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -29,7 +29,7 @@ USER_REVIEWER = NativeUser(
 
 REVIEWER_IDENTITY = {
     "_id": "edu.uci.alicia",
-    "role": "reviewer",
+    "roles": ["Organizer", "Reviewer"],
 }
 
 USER_DIRECTOR = NativeUser(
@@ -39,7 +39,7 @@ USER_DIRECTOR = NativeUser(
     affiliations=["student"],
 )
 
-DIRECTOR_IDENTITY = {"_id": "edu.uci.dir", "role": "director", "status": "CONFIRMED"}
+DIRECTOR_IDENTITY = {"_id": "edu.uci.dir", "roles": ["Organizer", "Director"]}
 
 app = FastAPI()
 app.include_router(admin.router)
@@ -58,7 +58,7 @@ def test_restricted_admin_route_is_forbidden(
 
     mock_mongodb_handler_retrieve_one.return_value = {
         "_id": "edu.uci.icssc",
-        "role": "mentor",
+        "roles": ["Mentor"],
     }
     res = unauthorized_client.get("/applicants")
 
@@ -91,8 +91,8 @@ def test_can_retrieve_applicants(
 
     res = reviewer_client.get("/applicants")
 
-    mock_mongodb_handler_retrieve.assert_awaited_once()
     assert res.status_code == 200
+    mock_mongodb_handler_retrieve.assert_awaited_once()
     data = res.json()
     assert data == [
         {
@@ -180,22 +180,18 @@ def test_confirm_attendance_route(
     mock_mongodb_handler_retrieve.return_value = [
         {
             "_id": "edu.uc.tester",
-            "role": "applicant",
             "status": Decision.ACCEPTED,
         },
         {
             "_id": "edu.uc.tester2",
-            "role": "applicant",
             "status": Status.WAIVER_SIGNED,
         },
         {
             "_id": "edu.uc.tester3",
-            "role": "applicant",
             "status": Status.CONFIRMED,
         },
         {
             "_id": "edu.uc.tester4",
-            "role": "applicant",
             "status": Decision.WAITLISTED,
         },
     ]

--- a/apps/api/tests/test_authorization.py
+++ b/apps/api/tests/test_authorization.py
@@ -32,8 +32,8 @@ async def test_rejected_applicant_is_unapplied(
     """User with applicant role and rejected status is not accepted."""
     mock_mongodb_handler_retrieve_one.return_value = {
         "_id": "edu.ucsd.tritons",
+        "roles": [Role.APPLICANT],
         "status": Decision.REJECTED,
-        "role": Role.APPLICANT,
         "first_name": "King",
         "last_name": "Triton",
     }
@@ -52,8 +52,8 @@ async def test_accepted_applicant_is_fine(
     """User with applicant role and accepted status is fine."""
     mock_mongodb_handler_retrieve_one.return_value = {
         "_id": "edu.berkeley.oski",
+        "roles": [Role.APPLICANT],
         "status": Decision.ACCEPTED,
-        "role": Role.APPLICANT,
         "first_name": "Oski",
         "last_name": "Bear",
     }
@@ -72,7 +72,7 @@ async def test_non_applicant_is_unapplied(
     """User with other role is not considered applicant."""
     mock_mongodb_handler_retrieve_one.return_value = {
         "_id": "edu.uci.hack",
-        "role": Role.DIRECTOR,
+        "roles": [Role.DIRECTOR],
     }
 
     with pytest.raises(HTTPException) as excinfo:

--- a/apps/api/tests/test_docusign_handler.py
+++ b/apps/api/tests/test_docusign_handler.py
@@ -45,7 +45,7 @@ async def test_new_waiver_submission_can_be_processed(
         "_id": SAMPLE_UID,
         "first_name": "Nicole",
         "last_name": "Pham",
-        "role": Role.APPLICANT,
+        "roles": [Role.APPLICANT],
         "status": Decision.ACCEPTED,
     }
     await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
@@ -65,7 +65,7 @@ async def test_no_op_when_user_already_signed_waiver(
         "_id": SAMPLE_UID,
         "first_name": "John",
         "last_name": "Hancock",
-        "role": Role.APPLICANT,
+        "roles": [Role.APPLICANT],
         "status": Status.CONFIRMED,
     }
     await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
@@ -83,7 +83,7 @@ async def test_no_op_for_rejected_applicant(
         "_id": SAMPLE_UID,
         "first_name": "King",
         "last_name": "Triton",
-        "role": Role.APPLICANT,
+        "roles": [Role.APPLICANT],
         "status": Decision.REJECTED,
     }
     await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
@@ -115,7 +115,8 @@ async def test_user_record_updated_even_for_non_applicant(
         "_id": SAMPLE_UID,
         "first_name": "Community",
         "last_name": "Service",
-        "role": Role.VOLUNTEER,
+        "roles": [Role.VOLUNTEER],
+        # Note: no status
     }
     await docusign_handler.process_webhook_event(SAMPLE_WEBHOOK_DATA)
     mock_mongodb_handler_update_one.assert_awaited_once_with(

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -55,8 +55,8 @@ async def test_retrieve_one_existing_document(mock_DB: MagicMock) -> None:
 async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
     """Test that multiple existing documents can be retrieved"""
     SAMPLE_DOCUMENTS = [
-        {"_id": 0, "role": "hacker"},
-        {"_id": 1, "role": "hacker"},
+        {"_id": 0, "roles": ["Hacker"]},
+        {"_id": 1, "roles": ["Hacker"]},
     ]
 
     mock_collection = Mock()
@@ -65,7 +65,7 @@ async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
     mock_collection.find.return_value = mock_cursor
     mock_DB.__getitem__.return_value = mock_collection
 
-    query = {"role": "hacker"}
+    query = {"roles": "Hacker"}
     result = await mongodb_handler.retrieve(Collection.TESTING, query)
     mock_collection.find.assert_called_once_with(query, [])
     assert result == SAMPLE_DOCUMENTS
@@ -146,7 +146,7 @@ async def test_update_existing_documents(mock_DB: MagicMock) -> None:
     mock_DB.__getitem__.return_value = mock_collection
 
     query = {"_id": "my-id"}
-    update = {"role": "hacker"}
+    update = {"status": "ACCEPTED"}
     result = await mongodb_handler.update(Collection.TESTING, query, update)
     mock_collection.update_many.assert_awaited_once_with(query, {"$set": update})
     assert result is True
@@ -159,7 +159,7 @@ async def test_update_existing_documents_failure(mock_DB: MagicMock) -> None:
     mock_collection.update_many.return_value = UpdateResult(dict(), False)
     mock_DB.__getitem__.return_value = mock_collection
 
-    update = {"role": "hacker"}
+    update = {"status": "ACCEPTED"}
     with pytest.raises(RuntimeError):
         query = {"_id": "my-id"}
         await mongodb_handler.update(Collection.TESTING, query, update)

--- a/apps/api/tests/test_user.py
+++ b/apps/api/tests/test_user.py
@@ -43,7 +43,7 @@ def test_no_identity_when_unauthenticated() -> None:
     """Test that identity is empty when not authenticated."""
     res = client.get("/me")
     data = res.json()
-    assert data == {"uid": None, "status": None, "role": None}
+    assert data == {"uid": None, "status": None, "roles": []}
 
 
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
@@ -56,10 +56,10 @@ def test_plain_identity_when_no_user_record(
     res = client.get("/me")
 
     mock_mongodb_handler_retrieve_one.assert_awaited_once_with(
-        Collection.USERS, {"_id": "edu.stanford.tree"}, ["role", "status"]
+        Collection.USERS, {"_id": "edu.stanford.tree"}, ["roles", "status"]
     )
     data = res.json()
-    assert data == {"uid": "edu.stanford.tree", "status": None, "role": None}
+    assert data == {"uid": "edu.stanford.tree", "status": None, "roles": []}
 
 
 @patch("services.mongodb_handler.update_one", autospec=True)
@@ -143,7 +143,7 @@ def test_user_me_route_returns_correct_type(
     """Test user me route returns correct fields as listed in user.IdentityResponse"""
     mock_mongodb_handler_retrieve_one.return_value = {
         "status": Status.WAIVER_SIGNED,
-        "role": Role.VOLUNTEER,
+        "roles": [Role.VOLUNTEER],
     }
 
     client = UserTestClient(GuestUser(email="tree@stanford.edu"), app)
@@ -153,5 +153,5 @@ def test_user_me_route_returns_correct_type(
     assert data == {
         "uid": "edu.stanford.tree",
         "status": Status.WAIVER_SIGNED,
-        "role": Role.VOLUNTEER,
+        "roles": [Role.VOLUNTEER],
     }

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -148,7 +148,7 @@ def test_apply_when_user_exists_causes_400(
     """Test that applying when a user already exists causes status 400."""
     mock_mongodb_handler_retrieve_one.return_value = {
         "_id": "edu.uci.pkfire",
-        "status": "pending review",
+        "roles": ["applicant"],
     }
     res = client.post("/apply", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
 
@@ -282,6 +282,7 @@ def test_application_data_is_bson_encodable() -> None:
 def test_application_data_with_other_throws_422(
     mock_mongodb_handler_retrieve_one: AsyncMock,
 ) -> None:
+    mock_mongodb_handler_retrieve_one.return_value = None
     contains_other = SAMPLE_APPLICATION.copy()
     contains_other["pronouns"] = "other"
     res = client.post("/apply", data=contains_other, files=SAMPLE_FILES)

--- a/apps/api/tests/test_user_waiver.py
+++ b/apps/api/tests/test_user_waiver.py
@@ -28,7 +28,7 @@ def test_accepted_user_can_request_waiver() -> None:
             uid=uid,
             first_name="Riley",
             last_name="Wong",
-            role=Role.APPLICANT,
+            roles=(Role.APPLICANT,),
             status=Decision.ACCEPTED,
         ),
     )
@@ -53,7 +53,7 @@ def test_cannot_request_waiver_if_already_signed() -> None:
             uid="edu.uci.hack",
             first_name="John",
             last_name="Hancock",
-            role=Role.APPLICANT,
+            roles=(Role.APPLICANT,),
             status=Status.WAIVER_SIGNED,
         ),
     )

--- a/apps/site/src/app/(main)/portal/layout.tsx
+++ b/apps/site/src/app/(main)/portal/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 
-import { isAdminRole } from "@/lib/admin/authorization";
+import { hasAdminRole } from "@/lib/admin/authorization";
 import getUserIdentity from "@/lib/utils/getUserIdentity";
 
 // TODO: include separate portals for Mentors and Volunteers
@@ -10,8 +10,8 @@ interface PortalLayoutProps {
 }
 
 async function PortalLayout({ admin, applicant }: PortalLayoutProps) {
-	const { role } = await getUserIdentity();
-	const content = isAdminRole(role) ? admin : applicant;
+	const { roles } = await getUserIdentity();
+	const content = hasAdminRole(roles) ? admin : applicant;
 
 	return (
 		<section className="w-full flex items-center flex-col min-h-screen">

--- a/apps/site/src/app/admin/applicants/Applicants.tsx
+++ b/apps/site/src/app/admin/applicants/Applicants.tsx
@@ -21,9 +21,9 @@ import { isApplicationManager } from "@/lib/admin/authorization";
 function Applicants() {
 	const router = useRouter();
 
-	const { role } = useContext(UserContext);
+	const { roles } = useContext(UserContext);
 
-	if (!isApplicationManager(role)) {
+	if (!isApplicationManager(roles)) {
 		router.push("/admin/dashboard");
 	}
 

--- a/apps/site/src/app/admin/applicants/[uid]/components/ApplicantActions.tsx
+++ b/apps/site/src/app/admin/applicants/[uid]/components/ApplicantActions.tsx
@@ -6,6 +6,7 @@ import ButtonDropdown, {
 
 import { Decision, submitReview, Uid } from "@/lib/admin/useApplicant";
 import UserContext from "@/lib/admin/UserContext";
+import { isReviewer } from "@/lib/admin/authorization";
 
 interface ApplicantActionsProps {
 	applicant: Uid;
@@ -19,9 +20,9 @@ interface ReviewButtonItem extends ButtonDropdownProps.Item {
 type ReviewButtonItems = ReviewButtonItem[];
 
 function ApplicantActions({ applicant, submitReview }: ApplicantActionsProps) {
-	const { role } = useContext(UserContext);
+	const { roles } = useContext(UserContext);
 
-	if (role !== "reviewer") {
+	if (!isReviewer(roles)) {
 		return null;
 	}
 

--- a/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
+++ b/apps/site/src/app/admin/dashboard/AdminDashboard.tsx
@@ -13,13 +13,13 @@ import ApplicantSummary from "./components/ApplicantSummary";
 import HackerCount from "./components/HackerCount";
 
 function AdminDashboard() {
-	const { role } = useContext(UserContext);
+	const { roles } = useContext(UserContext);
 
 	return (
 		<ContentLayout>
 			<SpaceBetween size="l">
 				<Container>Admin Dashboard</Container>
-				{isApplicationManager(role) && <ApplicantSummary />}
+				{isApplicationManager(roles) && <ApplicantSummary />}
 				<HackerCount />
 			</SpaceBetween>
 		</ContentLayout>

--- a/apps/site/src/app/admin/dashboard/components/HackerCount.tsx
+++ b/apps/site/src/app/admin/dashboard/components/HackerCount.tsx
@@ -16,7 +16,7 @@ function HackerCount() {
 	const { participants, loading } = useParticipants();
 
 	const checkedIn = participants
-		.filter((participant) => participant.role === Role.Applicant)
+		.filter((participant) => participant.roles.includes(Role.Applicant))
 		.filter((participant) =>
 			participant.checkins.some(([datetime]) =>
 				FRIDAY.isSame(dayjs(datetime).tz(EVENT_TIMEZONE), "date"),

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -8,7 +8,7 @@ import AppLayout from "@cloudscape-design/components/app-layout";
 import axios from "axios";
 import { SWRConfig } from "swr";
 
-import { isAdminRole } from "@/lib/admin/authorization";
+import { hasAdminRole } from "@/lib/admin/authorization";
 import UserContext from "@/lib/admin/UserContext";
 import useUserIdentity from "@/lib/admin/useUserIdentity";
 
@@ -23,9 +23,9 @@ function AdminLayout({ children }: PropsWithChildren) {
 		return "Loading...";
 	}
 
-	const { uid, role } = identity;
+	const { uid, roles } = identity;
 	const loggedIn = uid !== null;
-	const authorized = isAdminRole(role);
+	const authorized = hasAdminRole(roles);
 
 	if (!loggedIn) {
 		router.push("/login");

--- a/apps/site/src/app/admin/layout/AdminSidebar.tsx
+++ b/apps/site/src/app/admin/layout/AdminSidebar.tsx
@@ -15,7 +15,7 @@ function AdminSidebar() {
 	const pathname = usePathname();
 	const followWithNextLink = useFollowWithNextLink();
 
-	const { role } = useContext(UserContext);
+	const { roles } = useContext(UserContext);
 
 	const navigationItems: SideNavigationProps.Item[] = [
 		{ type: "link", text: "Dashboard", href: "/admin/dashboard" },
@@ -25,7 +25,7 @@ function AdminSidebar() {
 		{ type: "link", text: "Back to main site", href: "/" },
 	];
 
-	if (isApplicationManager(role)) {
+	if (isApplicationManager(roles)) {
 		navigationItems.splice(1, 0, {
 			type: "link",
 			text: "Applicants",

--- a/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
@@ -21,19 +21,19 @@ function ParticipantAction({
 	initiatePromotion,
 	initiateConfirm,
 }: ParticipantActionProps) {
-	const { role } = useContext(UserContext);
+	const { roles } = useContext(UserContext);
 
-	const isCheckin = isCheckinLead(role);
+	const canPromote = isCheckinLead(roles);
 	const isWaiverSigned = participant.status === Status.signed;
 	const isAccepted = participant.status === Status.accepted;
-	const nonHacker = isNonHacker(participant.role);
+	const nonHacker = isNonHacker(participant.roles);
 
 	const promoteButton = (
 		<Button
 			variant="inline-link"
 			ariaLabel={`Promote ${participant._id} off waitlist`}
 			onClick={() => initiatePromotion(participant)}
-			disabled={!isCheckin}
+			disabled={!canPromote}
 		>
 			Promote
 		</Button>
@@ -55,17 +55,17 @@ function ParticipantAction({
 			variant="inline-link"
 			ariaLabel={`Confirm attendance for ${participant._id}`}
 			onClick={() => initiateConfirm(participant)}
-			disabled={!isCheckin}
+			disabled={!canPromote}
 		>
 			Confirm
 		</Button>
 	);
 
 	if (nonHacker) {
-		const content = !isCheckinLead
+		const content = !canPromote
 			? "Only check-in leads can confirm non-hackers."
 			: "Must sign waiver first.";
-		if (!isCheckinLead || participant.status === ReviewStatus.reviewed) {
+		if (!canPromote || participant.status === ReviewStatus.reviewed) {
 			return (
 				<ParticipantActionPopover content={content}>
 					{confirmButton}
@@ -76,7 +76,7 @@ function ParticipantAction({
 		}
 		return checkinButton;
 	} else if (participant.status === Status.waitlisted) {
-		if (!isCheckin) {
+		if (!canPromote) {
 			return (
 				<ParticipantActionPopover content="Only check-in leads are allowed to promote walk-ins.">
 					{promoteButton}

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -11,7 +11,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table, { TableProps } from "@cloudscape-design/components/table";
 
 import ApplicantStatus from "@/app/admin/applicants/components/ApplicantStatus";
-import { Participant } from "@/lib/admin/useParticipants";
+import { Participant, Role } from "@/lib/admin/useParticipants";
 
 import CheckinDayIcon from "./CheckinDayIcon";
 import ParticipantAction from "./ParticipantAction";
@@ -42,7 +42,7 @@ const SEARCHABLE_COLUMNS: (keyof Participant)[] = [
 	"_id",
 	"first_name",
 	"last_name",
-	"role",
+	"roles",
 	"status",
 	"badge_number",
 ];
@@ -88,7 +88,7 @@ function ParticipantsTable({
 			"uid",
 			"firstName",
 			"lastName",
-			"role",
+			"roles",
 			"status",
 			"badgeNumber",
 			"friday",
@@ -100,7 +100,10 @@ function ParticipantsTable({
 	const [filterRole, setFilterRole] = useState<Options>([]);
 	const [filterStatus, setFilterStatus] = useState<Options>([]);
 	const matchesRole = (p: Participant) =>
-		filterRole.length === 0 || filterRole.map((r) => r.value).includes(p.role);
+		filterRole.length === 0 ||
+		filterRole
+			.map((r) => r.value)
+			.some((role) => p.roles.includes(role as Role));
 	const matchesStatus = (p: Participant) =>
 		filterStatus.length === 0 ||
 		filterStatus.map((s) => s.value).includes(p.status);
@@ -151,7 +154,7 @@ function ParticipantsTable({
 		selection: {},
 	});
 
-	const allRoles = new Set(participants.map((p) => p.role));
+	const allRoles = new Set(participants.flatMap((p) => p.roles));
 	const roleOptions = Array.from(allRoles).map((r) => ({ value: r, label: r }));
 	const allStatuses = new Set(participants.map((p) => p.status));
 	const statusOptions = Array.from(allStatuses).map((s) => ({
@@ -195,11 +198,11 @@ function ParticipantsTable({
 			sortingField: "last_name",
 		},
 		{
-			id: "role",
-			header: "Role",
+			id: "roles",
+			header: "Roles",
 			cell: RoleBadge,
-			ariaLabel: createLabelFunction("Role"),
-			sortingField: "role",
+			ariaLabel: createLabelFunction("Roles"),
+			sortingField: "roles",
 		},
 		{
 			id: "status",

--- a/apps/site/src/app/admin/participants/components/RoleBadge.tsx
+++ b/apps/site/src/app/admin/participants/components/RoleBadge.tsx
@@ -1,10 +1,17 @@
 import Badge from "@cloudscape-design/components/badge";
 
 import { Participant } from "@/lib/admin/useParticipants";
+import { SpaceBetween } from "@cloudscape-design/components";
 
-function RoleBadge({ role }: Participant) {
+function RoleBadge({ roles }: Participant) {
 	// TODO: custom colors
-	return <Badge>{role}</Badge>;
+	return (
+		<SpaceBetween size="xs">
+			{roles.map((role) => (
+				<Badge key={role}>{role}</Badge>
+			))}
+		</SpaceBetween>
+	);
 }
 
 export default RoleBadge;

--- a/apps/site/src/lib/admin/UserContext.ts
+++ b/apps/site/src/lib/admin/UserContext.ts
@@ -4,7 +4,7 @@ import { Identity } from "@/lib/utils/getUserIdentity";
 
 const UserContext = createContext<Identity>({
 	uid: null,
-	role: null,
+	roles: [],
 	status: null,
 });
 

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -1,30 +1,31 @@
-const ADMIN_ROLES = ["director", "reviewer", "checkin_lead"];
-const CHECKIN_ROLES = ["director", "checkin_lead"];
-const ORGANIZER_ROLES = ["organizer"];
+// TODO: refactor roles to enum somewhere else
+const MANAGER_ROLES = ["Director", "Reviewer", "Check-in Lead"];
 const NONHACKER_ROLES = [
-	"judge",
-	"sponsor",
-	"mentor",
-	"volunteer",
-	"workshop_lead",
+	"Judge",
+	"Sponsor",
+	"Mentor",
+	"Volunteer",
+	"Workshop Lead",
 ];
 
-export function isApplicationManager(role: string | null) {
-	return role !== null && ADMIN_ROLES.includes(role);
+export function isApplicationManager(roles: ReadonlyArray<string>) {
+	return roles.some((role) => MANAGER_ROLES.includes(role));
 }
 
-export function isAdminRole(role: string | null) {
-	return (
-		role !== null &&
-		(ADMIN_ROLES.includes(role) || ORGANIZER_ROLES.includes(role))
-	);
+// Conceptually, an admin is just a Hack organizer
+export function hasAdminRole(role: ReadonlyArray<string>) {
+	return role.includes("Organizer");
 }
 
-export function isCheckinLead(role: string | null) {
-	return role !== null && CHECKIN_ROLES.includes(role);
+export function isCheckinLead(roles: ReadonlyArray<string>) {
+	return roles.includes("Director") || roles.includes("Check-in Lead");
+}
+
+export function isReviewer(roles: ReadonlyArray<string>) {
+	return roles.includes("Reviewer");
 }
 
 // refactor: this function should be placed elsewhere later
-export function isNonHacker(role: string | null) {
-	return role !== null && NONHACKER_ROLES.includes(role);
+export function isNonHacker(roles: ReadonlyArray<string>) {
+	return roles.some((role) => NONHACKER_ROLES.includes(role));
 }

--- a/apps/site/src/lib/admin/useApplicant.ts
+++ b/apps/site/src/lib/admin/useApplicant.ts
@@ -52,7 +52,7 @@ export interface Applicant {
 	_id: Uid;
 	first_name: string;
 	last_name: string;
-	role: string;
+	roles: ReadonlyArray<string>;
 	status: Status;
 	application_data: ApplicationData;
 }

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -3,16 +3,18 @@ import useSWR from "swr";
 
 import { Status, Uid } from "@/lib/admin/useApplicant";
 
+// These should match `user_record.Role` in the API
+// TODO: move to common `userRecord` file
 export const enum Role {
-	Director = "director",
-	Organizer = "organizer",
-	CheckInLead = "checkin_lead",
-	Applicant = "applicant",
-	Mentor = "mentor",
-	Volunteer = "volunteer",
-	Sponsor = "sponsor",
-	Judge = "judge",
-	WorkshopLead = "workshop_lead",
+	Director = "Director",
+	Organizer = "Organizer",
+	CheckInLead = "Check-in Lead",
+	Applicant = "Applicant",
+	Mentor = "Mentor",
+	Volunteer = "Volunteer",
+	Sponsor = "Sponsor",
+	Judge = "Judge",
+	WorkshopLead = "Workshop Lead",
 }
 
 export type Checkin = [string, Uid];
@@ -21,7 +23,7 @@ export interface Participant {
 	_id: Uid;
 	first_name: string;
 	last_name: string;
-	role: Role;
+	roles: ReadonlyArray<Role>;
 	checkins: Checkin[];
 	status: Status;
 	badge_number: string | null;

--- a/apps/site/src/lib/utils/getUserIdentity.ts
+++ b/apps/site/src/lib/utils/getUserIdentity.ts
@@ -4,7 +4,7 @@ import api from "./api";
 
 export interface Identity {
 	uid: string | null;
-	role: string | null;
+	roles: ReadonlyArray<string>;
 	status: string | null;
 }
 
@@ -19,6 +19,6 @@ export default async function getUserIdentity(): Promise<Identity> {
 			// Don't think this case is possible/relevant but for completeness
 			console.error(err);
 		}
-		return { uid: null, role: null, status: null };
+		return { uid: null, roles: [], status: null };
 	}
 }


### PR DESCRIPTION
Potentially controversial change to how user roles are managed. Expecting this will allow for more flexibility for new admin features and also given the need to support other types of applicants in #386.

Resolves #421. See description of changes for notable modifications besides renaming the field.

#### Changes
- With the end goal of having more flexibility in assigning user roles, make `UserRecord` store multiple possible roles
  - Field is renamed to plural and modeled as a tuple or set
- Provide empty array in default user identity instead of `null`
  - Semantically `null` could be better to indicate unknown rather than explicitly no roles, but functionally, an empty array is simpler
- Constrain database query for `check_in_participant`
  - Still need unit tests for this
- Update role and status check for `confirm_attendance_non_hacker`
- Use `AfterValidator` for `Applicant.roles` to include `Role.APPLICANT`
- Reorganize admin authorization roles to reuse dependencies
  - Basic admin access is provided to anybody with the "Organizer" role
  - Directors will need to have both "Organizer" and "Director" roles
- Update logic for checking if user has already applied
- Fix logical bug in `ParticipantAction`: function was used like boolean
- Rename role strings to be the same as their display labels

#### Testing
Note any older records in the local database will need to be updated.
1. Impersonate a new user and submit an application
2. Observe in the database that the applicant has the correct default role: array with single entry of "Applicant"
3. Add another sample user record with the "Organizer" role
4. Impersonate said user and confirm the admin dashboard is accessible
5. Add an application manager role, e.g. "Reviewer" to said user
6. Observe the Applicants page of the admin site is accessible and the previously submitted application is included