### PR TITLE
Generalized ApplyConfirm to be used for each application form

### DIFF
--- a/apps/site/src/app/(main)/apply/page.tsx
+++ b/apps/site/src/app/(main)/apply/page.tsx
@@ -34,7 +34,7 @@ export default async function Apply({
 	const applicationsOpened = haveApplicationsOpened();
 	const applyBody = hasAcceptedQueryParam ? (
 		<>
-			<Title applicationType="Hacker"/>
+			<Title applicationType="Hacker" />
 			<div className="flex justify-center">
 				<Form />
 			</div>

--- a/apps/site/src/app/(main)/apply/page.tsx
+++ b/apps/site/src/app/(main)/apply/page.tsx
@@ -71,7 +71,7 @@ export default async function Apply({
 			</div>
 		</>
 	) : (
-		<ApplyConfirm />
+		<ApplyConfirm continueHREF="/apply" isNotHacker={false} />
 	);
 	return (
 		<div className="flex flex-col items-center gap-10 my-32 min-h-[calc(100vh-8rem)]">

--- a/apps/site/src/app/(main)/apply/page.tsx
+++ b/apps/site/src/app/(main)/apply/page.tsx
@@ -71,7 +71,7 @@ export default async function Apply({
 			</div>
 		</>
 	) : (
-		<ApplyConfirm continueHREF="/apply" isNotHacker={false} />
+		<ApplyConfirm continueHREF="/apply" isHacker={true} />
 	);
 	return (
 		<div className="flex flex-col items-center gap-10 my-32 min-h-[calc(100vh-8rem)]">

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
@@ -4,7 +4,7 @@ import ConfirmationDetails from "./ConfirmationDetails";
 export default async function ApplyConfirm() {
 	const identity = await getUserIdentity();
 	return (
-		<div className="flex flex-col items-center gap-10">
+		<div className="flex items-center w-screen h-screen">
 			<ConfirmationDetails isLoggedIn={identity.uid !== null} />
 		</div>
 	);

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
@@ -1,11 +1,27 @@
 import getUserIdentity from "@/lib/utils/getUserIdentity";
 import ConfirmationDetails from "./ConfirmationDetails";
 
-export default async function ApplyConfirm() {
+interface ApplyConfirmInterface {
+	continueHREF: string;
+	isNotHacker: boolean;
+}
+
+export default async function ApplyConfirm({
+	continueHREF,
+	isNotHacker,
+}: ApplyConfirmInterface) {
 	const identity = await getUserIdentity();
+	const roleText = isNotHacker
+		? "In addition, I understand that I must show up for my scheduled shifts."
+		: "In addition, I understand that I must check in at certain times on all three event days in order to be eligible to win prizes.";
+
 	return (
 		<div className="flex items-center w-screen h-screen">
-			<ConfirmationDetails isLoggedIn={identity.uid !== null} />
+			<ConfirmationDetails
+				continueHREF={continueHREF}
+				roleText={roleText}
+				isLoggedIn={identity.uid !== null}
+			/>
 		</div>
 	);
 }

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
@@ -15,7 +15,7 @@ export default async function ApplyConfirm({
 		? "In addition, I understand that I must check in at certain times on all three event days in order to be eligible to win prizes."
 		: "In addition, I understand that I must show up for my scheduled shifts.";
 	return (
-		<div className="flex items-center w-screen h-screen">
+		<div className="flex items-center py-16 px-10 min-w-screen min-h-screen">
 			<ConfirmationDetails
 				continueHREF={continueHREF}
 				roleText={roleText}

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ApplyConfirm.tsx
@@ -3,18 +3,17 @@ import ConfirmationDetails from "./ConfirmationDetails";
 
 interface ApplyConfirmInterface {
 	continueHREF: string;
-	isNotHacker: boolean;
+	isHacker: boolean;
 }
 
 export default async function ApplyConfirm({
 	continueHREF,
-	isNotHacker,
+	isHacker,
 }: ApplyConfirmInterface) {
 	const identity = await getUserIdentity();
-	const roleText = isNotHacker
-		? "In addition, I understand that I must show up for my scheduled shifts."
-		: "In addition, I understand that I must check in at certain times on all three event days in order to be eligible to win prizes.";
-
+	const roleText = isHacker
+		? "In addition, I understand that I must check in at certain times on all three event days in order to be eligible to win prizes."
+		: "In addition, I understand that I must show up for my scheduled shifts.";
 	return (
 		<div className="flex items-center w-screen h-screen">
 			<ConfirmationDetails

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -30,18 +30,6 @@ export default async function ConfirmationDetails({
 				text={isLoggedIn ? "Proceed to Application" : "Log in to Apply"}
 				href={isLoggedIn ? `${continueHREF}?prefaceAccepted=true` : "/login"}
 			/>
-			<hr className="mt-5 w-full h-0.5 bg-[#432810]" />
-			<p className="text-display">
-				Interested in helping out instead? Consider applying to be a{" "}
-				<a className="underline" href="/mentor">
-					mentor
-				</a>{" "}
-				or a{" "}
-				<a className="underline" href="/volunteer">
-					volunteer
-				</a>
-				.
-			</p>
 		</div>
 	);
 }

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -2,10 +2,14 @@ import Button from "@/lib/components/Button/Button";
 
 interface ConfirmationDetailsProps {
 	isLoggedIn: boolean;
+	continueHREF: string;
+	roleText: string;
 }
 
 export default async function ConfirmationDetails({
 	isLoggedIn,
+	continueHREF,
+	roleText,
 }: ConfirmationDetailsProps) {
 	return (
 		<div className="flex flex-col items-center gap-8 mx-20 p-6 md:px-10 md:py-8 border-[2px] md:border-[5px] border-[var(--color-white)] text-[var(--color-white)] bg-[var(--color-black)]">
@@ -14,18 +18,17 @@ export default async function ConfirmationDetails({
 				By submitting an application for IrvineHacks 2024, I understand that
 				IrvineHacks will take place in person during the day from January 26 to
 				28, and that IrvineHacks will not be providing transportation or
-				overnight accommodations. In addition, I understand that I must check in
-				at certain times on all three event days in order to be eligible to win
-				prizes. Lastly, I acknowledge that I am currently a student enrolled in
-				an accredited high school, college, or university in the United States
-				and will be over the age of 18 by January 26th, 2024.
+				overnight accommodations. {roleText} Lastly, I acknowledge that I am
+				currently a student enrolled in an accredited high school, college, or
+				university in the United States and will be over the age of 18 by
+				January 26th, 2024.
 			</p>
 			<strong className="text-lg text-[#FF2222]">
 				Applications are due on January 14th, 2024 at 11:59PM PST.
 			</strong>
 			<Button
 				text={isLoggedIn ? "Proceed to Application" : "Log in to Apply"}
-				href={isLoggedIn ? "/apply?prefaceAccepted=true" : "/login"}
+				href={isLoggedIn ? `${continueHREF}?prefaceAccepted=true` : "/login"}
 			/>
 			<hr className="mt-5 w-full h-0.5 bg-[#432810]" />
 			<p className="text-display">

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -27,8 +27,10 @@ export default async function ConfirmationDetails({
 				Applications are due on January 14th, 2024 at 11:59PM PST.
 			</strong>
 			<Button
+				className="text-2xl"
 				text={isLoggedIn ? "Proceed to Application" : "Log in to Apply"}
 				href={isLoggedIn ? `${continueHREF}?prefaceAccepted=true` : "/login"}
+				isLightVersion
 			/>
 		</div>
 	);

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -15,12 +15,13 @@ export default async function ConfirmationDetails({
 		<div className="flex flex-col items-center gap-8 p-10 md:p-6 md:px-10 md:py-8 border-[2px] md:border-[5px] border-[var(--color-white)] text-[var(--color-white)] bg-[var(--color-black)]">
 			<h1 className="text-5xl">Before Applying</h1>
 			<p className="text-lg">
-			By submitting an application for IrvineHacks 2025, I understand that
+				By submitting an application for IrvineHacks 2025, I understand that
 				IrvineHacks will take place in person during the day from January 24 to
 				26, and that IrvineHacks will not be providing transportation or
-				overnight accommodations. {roleText} Lastly, I acknowledge that I am currently a student enrolled in
-				an accredited high school, college, or university in the United States
-				and will be over the age of 18 by January 24th, 2025.
+				overnight accommodations. {roleText} Lastly, I acknowledge that I am
+				currently a student enrolled in an accredited high school, college, or
+				university in the United States and will be over the age of 18 by
+				January 24th, 2025.
 			</p>
 			<strong className="text-lg text-[#FF2222]">
 				Applications are due on January 10th, 2025 at 11:59PM PST.

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -1,5 +1,4 @@
 import Button from "@/lib/components/Button/Button";
-import styles from "./ConfirmationDetails.module.scss";
 
 interface ConfirmationDetailsProps {
 	isLoggedIn: boolean;
@@ -9,11 +8,9 @@ export default async function ConfirmationDetails({
 	isLoggedIn,
 }: ConfirmationDetailsProps) {
 	return (
-		<div
-			className={`${styles.details} w-8/12 flex flex-col items-center p-12 gap-10 z-1 max-[800px]:w-9/12 max-[400px]:w-11/12`}
-		>
-			<h1 className={`${styles.header} text-5xl`}>Before Applying</h1>
-			<p className={`${styles.policy} text-lg`}>
+		<div className="flex flex-col items-center gap-8 mx-20 p-6 md:px-10 md:py-8 border-[2px] md:border-[5px] border-[var(--color-white)] text-[var(--color-white)] bg-[var(--color-black)]">
+			<h1 className="text-5xl">Before Applying</h1>
+			<p className="text-lg">
 				By submitting an application for IrvineHacks 2024, I understand that
 				IrvineHacks will take place in person during the day from January 26 to
 				28, and that IrvineHacks will not be providing transportation or

--- a/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
+++ b/apps/site/src/app/(main)/apply/sections/ApplyConfirmation/ConfirmationDetails.tsx
@@ -12,7 +12,7 @@ export default async function ConfirmationDetails({
 	roleText,
 }: ConfirmationDetailsProps) {
 	return (
-		<div className="flex flex-col items-center gap-8 mx-20 p-6 md:px-10 md:py-8 border-[2px] md:border-[5px] border-[var(--color-white)] text-[var(--color-white)] bg-[var(--color-black)]">
+		<div className="flex flex-col items-center gap-8 p-10 md:p-6 md:px-10 md:py-8 border-[2px] md:border-[5px] border-[var(--color-white)] text-[var(--color-white)] bg-[var(--color-black)]">
 			<h1 className="text-5xl">Before Applying</h1>
 			<p className="text-lg">
 				By submitting an application for IrvineHacks 2024, I understand that


### PR DESCRIPTION
Intention is to use this in every application page following the structure of `app/(main)/apply/page.tsx`
for #395 and #396 

Changes:
- Added `continueHREF` prop
  - Intention is to set this to `/mentor` and `/volunteer` for their respective forms so their confirmations continue to those hrefs
- Added `isHacker` prop to display respective confirmation text
  - Added relevant text for each role