### PR TITLE
Implement RelayState for SAML authentication

### DIFF
--- a/apps/api/stubs/onelogin/saml2/auth.pyi
+++ b/apps/api/stubs/onelogin/saml2/auth.pyi
@@ -1,10 +1,18 @@
+from typing import Literal, Mapping, TypedDict
+
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
+
+class RequestData(TypedDict):
+    http_host: str  # the hostname
+    script_name: str  # the request path
+    https: Literal["on", "off"]
+    post_data: Mapping[str, str]
 
 class OneLogin_Saml2_Auth:
     def __init__(
         self,
-        request_data: dict[str, object],
-        old_settings: OneLogin_Saml2_Settings | dict[str, object] | None = ...,
+        request_data: RequestData,
+        old_settings: OneLogin_Saml2_Settings | Mapping[str, object] | None = ...,
         custom_base_path: str | None = ...,
     ) -> None: ...
     def process_response(self, request_id: str | None = None) -> None: ...


### PR DESCRIPTION
As part of #445, related to #446:

Implement SAML RelayState for our UCI SSO implementation. See [python3-saml README](https://github.com/SAML-Toolkits/python3-saml/blob/master/README.md) for further explanation about the SAML response to the ACS. In practice, the RelayState could be any URL (even on a different host), but to simplify things, we will enforce that only a pathname is provided, e.g. (`/portal`) without a host or protocol.

Once this is merged, the main login endpoint (`/user/login`) can forward a `return_to` query parameter to the SAML login endpoint, and a similar thing will need to be added for the guest login endpoint.

#### Changes
- Login endpoint takes in `return_to` parameter which is provided back together with the SAML Response as `RelayState`
- Simplify `_get_saml_auth` to remove unused request data
- Use explicit form fields for `SAMLResponse` and `RelayState` in ACS
- Improve unit tests

#### Testing
1. Will try to manually assign staging domain name to preview deployment (if Vercel cooperates)
2. Once ready, people can try navigating to `staging.irvinehacks.com/api/saml/login?return_to=%2Fmy-path`
3. After the UCI SSO, you should be redirected to `/my-path`