### PR TITLE
Added mentor app tests, addressed follow-up notes

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -58,15 +58,15 @@ class BaseMentorApplicationData(BaseModel):
     school: str
     major: str
     education_level: str
-    is_18_older: str
+    is_18_older: bool
     git_experience: str
     github: NullableHttpUrl = None
     portfolio: NullableHttpUrl = None
     linkedin: NullableHttpUrl = None
     mentor_prev_experience_saq1: Union[str, None] = Field(None, max_length=2048)
-    mentor_interest_saq2: Union[str, None] = Field(None, max_length=2048)
-    mentor_team_help_saq3: Union[str, None] = Field(None, max_length=2048)
-    mentor_team_help_saq4: Union[str, None] = Field(None, max_length=2048)
+    mentor_interest_saq2: str = Field(max_length=2048)
+    mentor_team_help_saq3: str = Field(max_length=2048)
+    mentor_team_help_saq4: str = Field(max_length=2048)
     other_questions: Union[str, None] = Field(None, max_length=2048)
 
 
@@ -105,7 +105,7 @@ class ProcessedMentorApplicationData(BaseMentorApplicationData):
     submission_time: datetime
     reviews: list[Review] = []
 
-    @field_serializer("linkedin", "portfolio", "resume_url")
+    @field_serializer("linkedin", "github", "portfolio", "resume_url")
     def url2str(self, val: Union[HttpUrl, None]) -> Union[str, None]:
         if val is not None:
             return str(val)

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -47,15 +47,15 @@ class BaseApplicationData(BaseModel):
     is_first_hackathon: bool
     linkedin: NullableHttpUrl = None
     portfolio: NullableHttpUrl = None
-    frq_change: Union[str, None] = Field(None, max_length=2048)
+    frq_change: str = Field(max_length=2048)
     frq_video_game: str = Field(max_length=2048)
 
 
 class BaseMentorApplicationData(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, str_max_length=254)
 
-    experienced_technologies: Optional[List[str]] = []
-    pronouns: Optional[List[str]] = []
+    experienced_technologies: List[str] = []
+    pronouns: List[str] = []
 
     school: str
     major: str
@@ -78,7 +78,7 @@ class RawHackerApplicationData(BaseApplicationData):
     first_name: str
     last_name: str
     resume: Union[UploadFile, None] = None
-    application_type: Literal["HACKER"]
+    application_type: Literal["Hacker"]
 
 
 class RawMentorApplicationData(BaseMentorApplicationData):
@@ -86,8 +86,8 @@ class RawMentorApplicationData(BaseMentorApplicationData):
 
     first_name: str
     last_name: str
-    resume: Union[UploadFile, None] = None
-    application_type: Literal["MENTOR"]
+    resume: UploadFile
+    application_type: Literal["Mentor"]
 
 
 class ProcessedHackerApplicationData(BaseApplicationData):

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Union
+from typing import Annotated, List, Optional, Union
 
 from fastapi import UploadFile
 from pydantic import (
@@ -52,8 +52,8 @@ class BaseApplicationData(BaseModel):
 class BaseMentorApplicationData(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, str_max_length=254)
 
-    experienced_technologies: str
-    pronouns: str
+    experienced_technologies: Optional[List[str]] = []
+    pronouns: Optional[List[str]] = []
 
     school: str
     major: str

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Union
 
 from fastapi import UploadFile
 from pydantic import (

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -127,6 +127,7 @@ def get_discriminator_value(v: Any) -> str:
         return "hacker"
     if "mentor_prev_experience_saq1" in dir(v):
         return "mentor"
+    return ""
 
 
 ProcessedApplicationDataUnion = Annotated[

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, List, Literal, Union
+from typing import Annotated, Any, Literal, Union
 
 from fastapi import UploadFile
 from pydantic import (
@@ -54,8 +54,8 @@ class BaseApplicationData(BaseModel):
 class BaseMentorApplicationData(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, str_max_length=254)
 
-    experienced_technologies: List[str] = []
-    pronouns: List[str] = []
+    experienced_technologies: list[str] = []
+    pronouns: list[str] = []
 
     school: str
     major: str

--- a/apps/api/src/models/user_record.py
+++ b/apps/api/src/models/user_record.py
@@ -73,6 +73,5 @@ class BareApplicant(UserRecord):
 class Applicant(BareApplicant):
     """Applicant with application data."""
 
-    # Note validators not run on default values
     roles: RoleWithApplicant
     application_data: ProcessedApplicationDataUnion

--- a/apps/api/src/models/user_record.py
+++ b/apps/api/src/models/user_record.py
@@ -6,8 +6,7 @@ from typing_extensions import TypeAlias
 
 from models.ApplicationData import (
     Decision,
-    ProcessedHackerApplicationData,
-    ProcessedMentorApplicationData,
+    ProcessedApplicationDataUnion,
 )
 from services.mongodb_handler import BaseRecord
 
@@ -75,7 +74,5 @@ class Applicant(BareApplicant):
     """Applicant with application data."""
 
     # Note validators not run on default values
-    roles: RoleWithApplicant = (Role.APPLICANT,)
-    application_data: Union[
-        ProcessedHackerApplicationData, ProcessedMentorApplicationData
-    ]
+    roles: RoleWithApplicant
+    application_data: ProcessedApplicationDataUnion

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -96,7 +96,13 @@ async def _apply_flow(
 
     raw_app_data_dump = raw_application_data.model_dump()
 
-    for field in ["pronouns", "ethnicity", "school", "major"]:
+    for field in [
+        "pronouns",
+        "ethnicity",
+        "school",
+        "major",
+        "experienced_technologies",
+    ]:
         value = raw_app_data_dump.get(field)
         if value == "other" or (isinstance(value, list) and "other" in value):
             raise HTTPException(
@@ -141,7 +147,7 @@ async def _apply_flow(
         uid=user.uid,
         first_name=raw_application_data.first_name,
         last_name=raw_application_data.last_name,
-        roles=(Role.APPLICANT, raw_application_data.application_type),  # type: ignore
+        roles=(Role.APPLICANT, Role(raw_application_data.application_type)),
         application_data=processed_application_data,
         status=Status.PENDING_REVIEW,
     )

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -73,7 +73,7 @@ async def me(
 
 async def _apply_flow(
     user: User,
-    raw_application_data: ProcessedApplicationDataUnion,
+    raw_application_data: Union[RawHackerApplicationData, RawMentorApplicationData],
 ) -> str:
     # Check if current datetime is past application deadline
     now = datetime.now(timezone.utc)
@@ -126,7 +126,7 @@ async def _apply_flow(
     else:
         resume_url = None
 
-    processed_application_data = {
+    processed_application_data: ProcessedApplicationDataUnion = {
         **raw_app_data_dump,
         "resume_url": resume_url,
         "submission_time": now,

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -75,12 +75,6 @@ async def _apply_flow(
     user: User,
     raw_application_data: Union[RawHackerApplicationData, RawMentorApplicationData],
 ) -> str:
-    if raw_application_data.application_type not in Role.__members__:
-        raise HTTPException(
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
-            "Invalid application type.",
-        )
-
     # Check if current datetime is past application deadline
     now = datetime.now(timezone.utc)
 

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -76,7 +76,6 @@ async def apply_flow(
     user: User,
     raw_application_data: Union[RawHackerApplicationData, RawMentorApplicationData],
 ) -> str:
-    print("apply_flow called")
     if raw_application_data.application_type not in Role.__members__:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -98,7 +98,7 @@ async def _apply_flow(
 
     for field in ["pronouns", "ethnicity", "school", "major"]:
         value = raw_app_data_dump.get(field)
-        if any([value == "other", isinstance(value, list) and "other" in value]):
+        if value == "other" or (isinstance(value, list) and "other" in value):
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
                 "Please enable JavaScript on your browser.",
@@ -141,7 +141,7 @@ async def _apply_flow(
         uid=user.uid,
         first_name=raw_application_data.first_name,
         last_name=raw_application_data.last_name,
-        roles=(Role.APPLICANT, Role[raw_application_data.application_type]),
+        roles=(Role.APPLICANT, raw_application_data.application_type),  # type: ignore
         application_data=processed_application_data,
         status=Status.PENDING_REVIEW,
     )
@@ -160,7 +160,7 @@ async def _apply_flow(
 
     try:
         await email_handler.send_application_confirmation_email(
-            user.email, applicant, Role[raw_application_data.application_type]
+            user.email, applicant, raw_application_data.application_type
         )
     except RuntimeError:
         log.error("Could not send confirmation email with SendGrid to %s.", user.uid)

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -126,7 +126,7 @@ async def _apply_flow(
     else:
         resume_url = None
 
-    processed_application_data: ProcessedApplicationDataUnion = {
+    processed_application_data = {
         **raw_app_data_dump,
         "resume_url": resume_url,
         "submission_time": now,

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -73,7 +73,7 @@ async def me(
 
 async def _apply_flow(
     user: User,
-    raw_application_data: Union[RawHackerApplicationData, RawMentorApplicationData],
+    raw_application_data: ProcessedApplicationDataUnion,
 ) -> str:
     # Check if current datetime is past application deadline
     now = datetime.now(timezone.utc)

--- a/apps/api/tests/test_applicant.py
+++ b/apps/api/tests/test_applicant.py
@@ -1,6 +1,6 @@
 from test_user_apply import EXPECTED_APPLICATION_DATA
 
-from models.user_record import Applicant, Status
+from models.user_record import Applicant, Role, Status
 
 
 def test_key_uid_not_in_applicant_model_dump() -> None:
@@ -8,6 +8,7 @@ def test_key_uid_not_in_applicant_model_dump() -> None:
         uid="edu.uci.sder",
         first_name="Sam",
         last_name="Der",
+        roles=(Role.APPLICANT,),
         status=Status.ATTENDING,
         application_data=EXPECTED_APPLICATION_DATA,
     )

--- a/apps/api/tests/test_user_apply.py
+++ b/apps/api/tests/test_user_apply.py
@@ -39,7 +39,7 @@ SAMPLE_APPLICATION = {
     "portfolio": "https://github.com",
     "frq_change": "I am pkfire",
     "frq_video_game": "I am pkfire",
-    "application_type": "HACKER",
+    "application_type": "Hacker",
 }
 
 

--- a/apps/api/tests/test_user_mentor_apply.py
+++ b/apps/api/tests/test_user_mentor_apply.py
@@ -28,8 +28,8 @@ USER_PKFIRE = NativeUser(
 SAMPLE_APPLICATION = {
     "first_name": "pk",
     "last_name": "fire",
-    "experienced_technologies": "",
-    "pronouns": "",
+    "experienced_technologies": [],
+    "pronouns": [],
     "is_18_older": "true",
     "school": "UC Irvine",
     "education_level": "Fifth+ Year Undergraduate",
@@ -261,7 +261,7 @@ def test_mentor_application_data_with_other_throws_422(
 ) -> None:
     mock_mongodb_handler_retrieve_one.return_value = None
     contains_other = SAMPLE_APPLICATION.copy()
-    contains_other["pronouns"] = "other"
+    contains_other["pronouns"].append("other")
     res = client.post("/mentor", data=contains_other, files=SAMPLE_FILES)
     assert res.status_code == 422
 

--- a/apps/api/tests/test_user_mentor_apply.py
+++ b/apps/api/tests/test_user_mentor_apply.py
@@ -261,7 +261,7 @@ def test_mentor_application_data_with_other_throws_422(
 ) -> None:
     mock_mongodb_handler_retrieve_one.return_value = None
     contains_other = SAMPLE_APPLICATION.copy()
-    contains_other["pronouns"].append("other")
+    contains_other["pronouns"].append("other")  # type: ignore[attr-defined]
     res = client.post("/mentor", data=contains_other, files=SAMPLE_FILES)
     assert res.status_code == 422
 

--- a/apps/api/tests/test_user_mentor_apply.py
+++ b/apps/api/tests/test_user_mentor_apply.py
@@ -1,13 +1,13 @@
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
+import bson
+from aiogoogle import HTTPError
 from fastapi import FastAPI
 from pydantic import HttpUrl
 
 from auth.user_identity import NativeUser, UserTestClient
-from models.ApplicationData import (
-    ProcessedMentorApplicationData,
-)
+from models.ApplicationData import ProcessedMentorApplicationData
 from models.user_record import Applicant, Status, Role
 from routers import user
 from services.mongodb_handler import Collection
@@ -51,13 +51,6 @@ SAMPLE_RESUME = ("my-resume.pdf", b"resume", "application/pdf")
 SAMPLE_FILES = {"resume": SAMPLE_RESUME}
 BAD_RESUME = ("bad-resume.doc", b"resume", "application/msword")
 LARGE_RESUME = ("large-resume.pdf", b"resume" * 100_000, "application/pdf")
-# The browser will send an empty file if not selected
-EMPTY_RESUME = (
-    "",
-    b"",
-    "application/octet-stream",
-    {"content-disposition": 'form-data; name="resume"; filename=""'},
-)
 
 EXPECTED_RESUME_UPLOAD = ("pk-fire-69f2afc2.pdf", b"resume", "application/pdf")
 SAMPLE_RESUME_URL = HttpUrl("https://drive.google.com/file/d/...")
@@ -72,12 +65,6 @@ EXPECTED_APPLICATION_DATA = ProcessedMentorApplicationData(
 )
 assert EXPECTED_APPLICATION_DATA.linkedin is None
 
-EXPECTED_APPLICATION_DATA_WITHOUT_RESUME = ProcessedMentorApplicationData(
-    **SAMPLE_APPLICATION,  # type: ignore[arg-type]
-    resume_url=None,
-    submission_time=SAMPLE_SUBMISSION_TIME,
-    verdict_time=SAMPLE_VERDICT_TIME,
-)
 
 EXPECTED_USER = Applicant(
     uid="edu.uci.pkfire",
@@ -86,15 +73,6 @@ EXPECTED_USER = Applicant(
     roles=(Role.APPLICANT, Role.MENTOR),
     application_data=EXPECTED_APPLICATION_DATA,
     status=Status.PENDING_REVIEW,
-)
-
-EXPECTED_USER_WITHOUT_RESUME = Applicant(
-    uid="edu.uci.pkfire",
-    first_name="pk",
-    last_name="fire",
-    roles=(Role.APPLICANT, Role.HACKER),
-    status=Status.PENDING_REVIEW,
-    application_data=EXPECTED_APPLICATION_DATA_WITHOUT_RESUME,
 )
 
 resume_handler.RESUMES_FOLDER_ID = "RESUMES_FOLDER_ID"
@@ -139,3 +117,160 @@ def test_mentor_apply_successfully(
         USER_EMAIL, EXPECTED_USER, Role.MENTOR
     )
     assert res.status_code == 201
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_invalid_data_causes_422(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """Test that applying with invalid data is unprocessable."""
+    bad_application = SAMPLE_APPLICATION.copy()
+    bad_application["github"] = "ht."
+    res = client.post("/mentor", data=bad_application, files=SAMPLE_FILES)
+
+    mock_mongodb_handler_retrieve_one.assert_not_called()
+    assert res.status_code == 422
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_invalid_application_type_causes_422(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """Test that applying with invalid data is unprocessable."""
+    bad_application = SAMPLE_APPLICATION.copy()
+    bad_application["application_type"] = "NotValid"
+    res = client.post("/mentor", data=bad_application, files=SAMPLE_FILES)
+
+    mock_mongodb_handler_retrieve_one.assert_not_called()
+    assert res.status_code == 422
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_when_user_exists_causes_400(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that applying when a user already exists causes status 400."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "_id": "edu.uci.pkfire",
+        "roles": ["applicant"],
+    }
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    mock_gdrive_handler_upload_file.assert_not_called()
+    assert res.status_code == 400
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_invalid_resume_type_causes_415(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    """Test that applying with an invalid resume type is unprocessable."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files={"resume": BAD_RESUME})
+
+    assert res.status_code == 415
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_large_resume_causes_413(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that a request with a resume over the size limit causes status 413."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    res = client.post(
+        "/mentor", data=SAMPLE_APPLICATION, files={"resume": LARGE_RESUME}
+    )
+
+    mock_gdrive_handler_upload_file.assert_not_called()
+    assert res.status_code == 413
+
+
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_resume_upload_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+) -> None:
+    """Test that an issue with the resume upload causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.side_effect = HTTPError("Google Drive error")
+
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    assert res.status_code == 500
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_user_insert_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that an issue with inserting a user into MongoDB causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
+    mock_mongodb_handler_update_one.side_effect = RuntimeError
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    assert res.status_code == 500
+    mock_mongodb_handler_update_one.assert_awaited_once()
+    mock_send_application_confirmation_email.assert_not_called()
+
+
+@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
+@patch("services.mongodb_handler.update_one", autospec=True)
+@patch("services.gdrive_handler.upload_file", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_apply_with_confirmation_email_issue_causes_500(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_gdrive_handler_upload_file: AsyncMock,
+    mock_mongodb_handler_update_one: AsyncMock,
+    mock_send_application_confirmation_email: AsyncMock,
+) -> None:
+    """Test that an issue with sending the confirmation email causes status 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_gdrive_handler_upload_file.return_value = SAMPLE_RESUME_URL
+    mock_send_application_confirmation_email.side_effect = RuntimeError
+
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+
+    assert res.status_code == 500
+    mock_mongodb_handler_update_one.assert_awaited_once()
+    mock_send_application_confirmation_email.assert_awaited_once()
+
+
+def test_mentor_application_data_is_bson_encodable() -> None:
+    """Test that application data model can be encoded into BSON to store in MongoDB."""
+    data = EXPECTED_APPLICATION_DATA.model_copy()
+    data.linkedin = HttpUrl("https://linkedin.com")
+    encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
+    assert len(encoded) == 467
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_mentor_application_data_with_other_throws_422(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+) -> None:
+    mock_mongodb_handler_retrieve_one.return_value = None
+    contains_other = SAMPLE_APPLICATION.copy()
+    contains_other["pronouns"] = "other"
+    res = client.post("/mentor", data=contains_other, files=SAMPLE_FILES)
+    assert res.status_code == 422
+
+
+def test_mentor_past_deadline_causes_403() -> None:
+    """Test that users are forbidden from submitting applications past the deadline."""
+    user.DEADLINE = datetime(2023, 12, 18, 20, 0, 0, tzinfo=timezone.utc)
+
+    res = client.post("/mentor", data=SAMPLE_APPLICATION, files=SAMPLE_FILES)
+    assert res.status_code == 403
+
+    user.DEADLINE = TEST_DEADLINE

--- a/apps/api/tests/test_user_mentor_apply.py
+++ b/apps/api/tests/test_user_mentor_apply.py
@@ -43,7 +43,7 @@ SAMPLE_APPLICATION = {
     "mentor_team_help_saq3": "",
     "mentor_team_help_saq4": "",
     "other_questions": "",
-    "application_type": "MENTOR",
+    "application_type": "Mentor",
 }
 
 

--- a/apps/site/src/app/(main)/apply/Form/HackerBasicInformation.tsx
+++ b/apps/site/src/app/(main)/apply/Form/HackerBasicInformation.tsx
@@ -21,8 +21,8 @@ const ethnicity = [
 ];
 
 const yesNoOptions = [
-	{ value: "hack-yes", text: "Yes" },
-	{ value: "hack-no", text: "No" },
+	{ value: "Yes", text: "Yes" },
+	{ value: "No", text: "No" },
 ];
 
 export default function BasicInformation() {

--- a/apps/site/src/app/(main)/apply/Form/HackerForm.tsx
+++ b/apps/site/src/app/(main)/apply/Form/HackerForm.tsx
@@ -1,5 +1,5 @@
 import AgeInformation from "@/lib/components/forms/shared/AgeInformation";
-import Form from "@/lib/components/forms/shared/BaseForm";
+import BaseForm from "@/lib/components/forms/shared/BaseForm";
 import SchoolInformation from "@/lib/components/forms/shared/SchoolInformation";
 import ResumeInformation from "@/lib/components/forms/shared/ResumeInformation";
 
@@ -8,12 +8,12 @@ import ProfileInformation from "./ProfileInformation";
 
 export default function HackerForm() {
 	return (
-		<Form applicationType="HACKER">
+		<BaseForm applicationType="HACKER" applyPath="/api/user/apply">
 			<BasicInformation />
 			<SchoolInformation />
 			<ProfileInformation />
 			<ResumeInformation />
 			<AgeInformation />
-		</Form>
+		</BaseForm>
 	);
 }

--- a/apps/site/src/app/(main)/apply/Form/HackerForm.tsx
+++ b/apps/site/src/app/(main)/apply/Form/HackerForm.tsx
@@ -8,7 +8,7 @@ import ProfileInformation from "./ProfileInformation";
 
 export default function HackerForm() {
 	return (
-		<BaseForm applicationType="HACKER" applyPath="/api/user/apply">
+		<BaseForm applicationType="Hacker" applyPath="/api/user/apply">
 			<BasicInformation />
 			<SchoolInformation />
 			<ProfileInformation />

--- a/apps/site/src/app/(main)/apply/Form/ProfileInformation.tsx
+++ b/apps/site/src/app/(main)/apply/Form/ProfileInformation.tsx
@@ -1,6 +1,9 @@
 import Textfield from "@/lib/components/forms/Textfield";
 import TextInput from "@/lib/components/forms/TextInput";
 
+// The length here is different from the length specified in API data models.
+// This was originally done because different browsers used to count newline characters slightly differently
+// Currently unsure if this is still the case
 const FRQ_MAX_LENGTH = 2000;
 
 export default function ProfileInformation() {

--- a/apps/site/src/app/(main)/mentor/Form/MentorForm.tsx
+++ b/apps/site/src/app/(main)/mentor/Form/MentorForm.tsx
@@ -14,7 +14,7 @@ import MultipleSelect from "@/lib/components/forms/MultipleSelect";
 
 export default function MentorForm() {
 	return (
-		<BaseForm applicationType="MENTOR">
+		<BaseForm applicationType="MENTOR" applyPath="/api/user/mentor">
 			<BasicInformation />
 			<SchoolInformation />
 			<ShortAnswers />

--- a/apps/site/src/app/(main)/mentor/Form/MentorForm.tsx
+++ b/apps/site/src/app/(main)/mentor/Form/MentorForm.tsx
@@ -14,7 +14,7 @@ import MultipleSelect from "@/lib/components/forms/MultipleSelect";
 
 export default function MentorForm() {
 	return (
-		<BaseForm applicationType="MENTOR" applyPath="/api/user/mentor">
+		<BaseForm applicationType="Mentor" applyPath="/api/user/mentor">
 			<BasicInformation />
 			<SchoolInformation />
 			<ShortAnswers />

--- a/apps/site/src/app/(main)/volunteer/VolunteerForm.tsx
+++ b/apps/site/src/app/(main)/volunteer/VolunteerForm.tsx
@@ -9,7 +9,7 @@ import ExtraQuestions from "./components/ExtraQuestions";
 
 export default function VolunteerForm() {
 	return (
-		<BaseForm applicationType="VOLUNTEER" applyPath="/api/user/volunteer">
+		<BaseForm applicationType="Volunteer" applyPath="/api/user/volunteer">
 			<BasicInformation />
 			<SchoolInformation />
 			<VolunteerFRQ />

--- a/apps/site/src/app/(main)/volunteer/VolunteerForm.tsx
+++ b/apps/site/src/app/(main)/volunteer/VolunteerForm.tsx
@@ -9,7 +9,7 @@ import ExtraQuestions from "./components/ExtraQuestions";
 
 export default function VolunteerForm() {
 	return (
-		<BaseForm applicationType="VOLUNTEER">
+		<BaseForm applicationType="VOLUNTEER" applyPath="/api/user/volunteer">
 			<BasicInformation />
 			<SchoolInformation />
 			<VolunteerFRQ />

--- a/apps/site/src/lib/components/forms/shared/BaseForm.tsx
+++ b/apps/site/src/lib/components/forms/shared/BaseForm.tsx
@@ -15,14 +15,16 @@ const FIELDS_WITH_OTHER = [
 	"experienced_technologies",
 ];
 
+interface BaseFormProps {
+	applicationType: string;
+	applyPath: string;
+}
+
 export default function BaseForm({
 	applicationType,
 	applyPath,
 	children,
-}: {
-	applicationType: string;
-	applyPath: string;
-} & PropsWithChildren) {
+}: PropsWithChildren<BaseFormProps>) {
 	const [submitting, setSubmitting] = useState(false);
 	const [sessionExpired, setSessionExpired] = useState(false);
 

--- a/apps/site/src/lib/components/forms/shared/BaseForm.tsx
+++ b/apps/site/src/lib/components/forms/shared/BaseForm.tsx
@@ -7,7 +7,6 @@ import Button from "@/lib/components/Button/Button";
 
 import hasDeadlinePassed from "@/lib/utils/hasDeadlinePassed";
 
-const APPLY_PATH = "/api/user/apply";
 const FIELDS_WITH_OTHER = [
 	"pronouns",
 	"ethnicity",
@@ -18,9 +17,11 @@ const FIELDS_WITH_OTHER = [
 
 export default function BaseForm({
 	applicationType,
+	applyPath,
 	children,
 }: {
 	applicationType: string;
+	applyPath: string;
 } & PropsWithChildren) {
 	const [submitting, setSubmitting] = useState(false);
 	const [sessionExpired, setSessionExpired] = useState(false);
@@ -66,7 +67,7 @@ export default function BaseForm({
 		formData.append("application_type", applicationType);
 
 		try {
-			const res = await axios.post(APPLY_PATH, formData);
+			const res = await axios.post(applyPath, formData);
 			if (res.status === 201) {
 				console.log("Application submitted");
 
@@ -102,7 +103,7 @@ export default function BaseForm({
 		<form
 			method="post"
 			className="bg-black border-[5px] border-white text-[var(--color-white)] w-8/12 flex flex-col items-center py-12 gap-14 z-1 max-[800px]:w-9/12 max-[400px]:w-11/12 drop-shadow-[25px_33px_0px_rgba(255,255,255,1)]"
-			action="/api/user/apply"
+			action={applyPath}
 			encType="multipart/form-data"
 			onSubmit={handleSubmit}
 		>

--- a/apps/site/src/lib/components/forms/shared/BaseForm.tsx
+++ b/apps/site/src/lib/components/forms/shared/BaseForm.tsx
@@ -16,7 +16,7 @@ const FIELDS_WITH_OTHER = [
 ];
 
 interface BaseFormProps {
-	applicationType: "HACKER" | "MENTOR" | "VOLUNTEER";
+	applicationType: "Hacker" | "Mentor" | "Volunteer";
 	applyPath: string;
 }
 

--- a/apps/site/src/lib/components/forms/shared/BaseForm.tsx
+++ b/apps/site/src/lib/components/forms/shared/BaseForm.tsx
@@ -16,7 +16,7 @@ const FIELDS_WITH_OTHER = [
 ];
 
 interface BaseFormProps {
-	applicationType: string;
+	applicationType: "HACKER" | "MENTOR" | "VOLUNTEER";
 	applyPath: string;
 }
 
@@ -65,9 +65,6 @@ export default function BaseForm({
 			if (otherFieldValue) formData.append(field, otherFieldValue);
 		}
 
-		// attach application type to formData
-		formData.append("application_type", applicationType);
-
 		try {
 			const res = await axios.post(applyPath, formData);
 			if (res.status === 201) {
@@ -109,6 +106,13 @@ export default function BaseForm({
 			encType="multipart/form-data"
 			onSubmit={handleSubmit}
 		>
+			<input
+				type="text"
+				name="application_type"
+				value={applicationType}
+				readOnly
+				hidden
+			/>
 			{children}
 			<Button
 				text="Submit"


### PR DESCRIPTION
Added tests for mentor apps.

Also addresses notes to close #455 and close #456

---

From #455:
- In `ApplicationData.py` declared `ProcessedApplicationData` as a discriminated union
  - Removed manual type checking in `_apply_flow`
- Used Literal type for `application_type` in `user_record.Applicant`
- Removed manual check for `application_type` in `_apply_flow`
- Simplified checking other fields, but added checking for inclusion in list (for multiple pronouns and experienced_technolgoies)
- Removed default value for roles in `UserRecord.Applicant`

From #456 
- Used hidden input field for application type
- Included comment explaining why FRQ length limit is lower on the site than in the API
- Simplify usage of `PropsWithChildren` in `BaseForm`