### PR TITLE
Mock external services during local development

### DIFF
--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -4,21 +4,26 @@ import os
 from fastapi import FastAPI
 
 from routers import admin, demo, guest, saml, user
+from utils import dev_mock
 
 logging.basicConfig(level=logging.INFO)
 
-app = FastAPI()
+
+# TODO: check FastAPI CLI usage instead
+if os.getenv("DEPLOYMENT") == "LOCAL":
+    from routers import dev
+
+    # Set `root_path` for docs to be accessible at localhost:3000/api/docs
+    app = FastAPI(root_path="/api/", lifespan=dev_mock.lifespan)
+    app.include_router(dev.router, prefix="/dev", tags=["dev"])
+else:
+    app = FastAPI()
 
 app.include_router(saml.router, prefix="/saml", tags=["saml"])
 app.include_router(demo.router, prefix="/demo", tags=["demo"])
 app.include_router(guest.router, prefix="/guest", tags=["guest"])
 app.include_router(user.router, prefix="/user", tags=["user"])
 app.include_router(admin.router, prefix="/admin", tags=["admin"])
-
-if os.getenv("DEPLOYMENT") == "LOCAL":
-    from routers import dev
-
-    app.include_router(dev.router, prefix="/dev")
 
 
 @app.get("/")

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -4,7 +4,6 @@ import os
 from fastapi import FastAPI
 
 from routers import admin, demo, guest, saml, user
-from utils import dev_mock
 
 logging.basicConfig(level=logging.INFO)
 
@@ -12,6 +11,7 @@ logging.basicConfig(level=logging.INFO)
 # TODO: check FastAPI CLI usage instead
 if os.getenv("DEPLOYMENT") == "LOCAL":
     from routers import dev
+    from utils import dev_mock
 
     # Set `root_path` for docs to be accessible at localhost:3000/api/docs
     app = FastAPI(root_path="/api/", lifespan=dev_mock.lifespan)

--- a/apps/api/src/routers/dev.py
+++ b/apps/api/src/routers/dev.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from fastapi.responses import RedirectResponse
 
 from auth import user_identity
-from auth.user_identity import COOKIE_NAME, NativeUser
+from auth.user_identity import NativeUser
 
 router = APIRouter()
 
@@ -18,7 +18,5 @@ async def impersonate(ucinetid: str) -> RedirectResponse:
     )
 
     res = RedirectResponse("/portal", status_code=303)
-
-    jwt_token = user_identity._generate_jwt_token(user)
-    res.set_cookie(COOKIE_NAME, jwt_token, max_age=4000, httponly=True)
+    user_identity.issue_user_identity(user, res)
     return res

--- a/apps/api/src/routers/guest.py
+++ b/apps/api/src/routers/guest.py
@@ -52,8 +52,10 @@ async def guest_login(
     )
 
     if not confirmation:
+        log.info("Guest %s recently requested a passphrase, ignoring request.", email)
         return response
 
+    log.info("%s initiated guest login", email)
     response.set_cookie(
         "guest_confirmation", confirmation, max_age=600, secure=True, httponly=True
     )

--- a/apps/api/src/utils/dev_mock.py
+++ b/apps/api/src/utils/dev_mock.py
@@ -1,0 +1,71 @@
+import base64
+import hashlib
+import random
+from contextlib import asynccontextmanager
+from logging import getLogger
+from typing import Any, AsyncIterator, Iterable, Union
+from unittest.mock import patch
+
+from fastapi import FastAPI, Response
+from fastapi.responses import RedirectResponse
+
+from services.sendgrid_handler import Template
+
+log = getLogger(__name__)
+
+SAMPLE_RESUMES_FOLDER_ID = "1a_Hacker_Resumes"
+
+
+def mock_set_cookie(self: RedirectResponse, *args: Any, **kwargs: Any) -> None:
+    """Allow cookies on non-https for local development."""
+    kwargs["secure"] = False
+    return Response.set_cookie(self, *args, **kwargs)
+
+
+async def mock_send_email(
+    template_id: Template,
+    sender_email: tuple[str, str],
+    receiver_data: Union[dict[str, str], Iterable[dict[str, str]]],
+    send_to_multiple: bool = False,
+) -> None:
+    """Mock sending of email through SendGrid."""
+    if send_to_multiple:
+        log.info(
+            "Simulating sending %s email to %s", template_id.name, list(receiver_data)
+        )
+    else:
+        log.info("Simulating sending %s email to %s", template_id.name, receiver_data)
+
+
+async def mock_upload_file(
+    folder_id: str, file_name: str, file_bytes: bytes, file_type: str
+) -> str:
+    """Mock uploading file to Google Drive."""
+    log.info(
+        "Simulating upload of file %s (%s, %s bytes) to %s",
+        file_name,
+        file_type,
+        len(file_bytes),
+        folder_id,
+    )
+    digest = base64.b64encode(hashlib.sha256(file_bytes).digest() + random.randbytes(7))
+    file_id = digest.decode().replace("+", "_").replace("/", "_")
+    return f"https://drive.irvinehacks.com/file/NOT_REAL/1c{file_id}"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Patch usage of external services for local development."""
+
+    # Important: these must be imported as `from services import handler`
+    # rather than `from services.handler import function` when used to be patched
+    patch(
+        "utils.resume_handler.RESUMES_FOLDER_ID", new=SAMPLE_RESUMES_FOLDER_ID
+    ).start()
+    patch("services.gdrive_handler.upload_file", new=mock_upload_file).start()
+    patch("services.sendgrid_handler.send_email", new=mock_send_email).start()
+
+    patch.object(RedirectResponse, "set_cookie", new=mock_set_cookie).start()
+
+    yield
+    patch.stopall()

--- a/apps/api/src/utils/dev_mock.py
+++ b/apps/api/src/utils/dev_mock.py
@@ -10,10 +10,12 @@ from fastapi import FastAPI, Response
 from fastapi.responses import RedirectResponse
 
 from services.sendgrid_handler import Template
+from utils import resume_handler
 
 log = getLogger(__name__)
 
-SAMPLE_RESUMES_FOLDER_ID = "1a_Hacker_Resumes"
+_HACKER_RESUMES_FOLDER_ID = "1a_Hacker_Resumes"
+_MENTOR_RESUMES_FOLDER_ID = "1b_Mentor_Resumes"
 
 
 def mock_set_cookie(self: RedirectResponse, *args: Any, **kwargs: Any) -> None:
@@ -59,11 +61,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Important: these must be imported as `from services import handler`
     # rather than `from services.handler import function` when used to be patched
-    patch(
-        "utils.resume_handler.RESUMES_FOLDER_ID", new=SAMPLE_RESUMES_FOLDER_ID
-    ).start()
     patch("services.gdrive_handler.upload_file", new=mock_upload_file).start()
     patch("services.sendgrid_handler.send_email", new=mock_send_email).start()
+
+    patch.object(
+        resume_handler, "HACKER_RESUMES_FOLDER_ID", new=_HACKER_RESUMES_FOLDER_ID
+    ).start()
+    patch.object(
+        resume_handler, "MENTOR_RESUMES_FOLDER_ID", new=_MENTOR_RESUMES_FOLDER_ID
+    ).start()
 
     patch.object(RedirectResponse, "set_cookie", new=mock_set_cookie).start()
 


### PR DESCRIPTION
Resolves #447: Adding mocks for external services to simplify local development by patching service handlers during the [app lifespan](https://fastapi.tiangolo.com/advanced/events/#lifespan).

Later want to replace checking the `DEPLOYMENT` environment variable with checking for entering from the FastAPI CLI while working on #420.

#### Changes
- When testing the API server, patch usage of external services
  - Mock uploading file to Google Drive and sending emails with SendGrid
  - Remove `Secure` attribute from cookies on `RedirectResponse`
    - Also simplifies issuing user identity in `dev.impersonate`
- Add additional log messages for guest authentication flow

#### Testing
1. Launch the API dev server with the MongoDB instance: `npm run dev` from `apps/api`
   - Make sure you have a document with the `_id` field equal `word_list` and a field called `word` of an array of strings inside the collection `irvinehacks-prod.settings`
2. Complete the guest authentication process: the passphrase should be shown as a mocked email in the logs
3. Submit an application with a resume file
4. Observe the file upload is mocked, and a fake URL is generated
5. Observe the confirmation email is also mocked
6. Verify that impersonating a dev user still works