### PR TITLE
Redesign data model for volunteer availability

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -31,6 +31,15 @@ def make_empty_none(val: Union[str, None]) -> Union[str, None]:
     return val
 
 
+FIELDS_SUPPORTING_OTHER = [
+    "pronouns",
+    "ethnicity",
+    "school",
+    "major",
+    "experienced_technologies",
+]
+
+
 NullableHttpUrl = Annotated[Union[None, HttpUrl], BeforeValidator(make_empty_none)]
 
 
@@ -50,28 +59,6 @@ class BaseApplicationData(BaseModel):
     portfolio: NullableHttpUrl = None
     frq_change: str = Field(max_length=2048)
     frq_video_game: str = Field(max_length=2048)
-
-
-class BaseVolunteerApplicationData(BaseModel):
-    model_config = ConfigDict(str_strip_whitespace=True, str_max_length=1024)
-
-    pronouns: list[str] = []
-    ethnicity: str
-    is_18_older: bool
-    school: str
-    education_level: str
-    major: str
-    applied_before: bool
-    frq_volunteer: str = Field(max_length=2048)
-    frq_utensil: str = Field(max_length=2048)
-    allergies: Union[str, None] = Field(None, max_length=2048)
-    extra_questions: Union[str, None] = Field(None, max_length=2048)
-
-
-class VolunteerApplicationData(BaseVolunteerApplicationData):
-    friday_availability: str
-    saturday_availability: str
-    sunday_availability: str
 
 
 class BaseMentorApplicationData(BaseModel):
@@ -96,6 +83,29 @@ class BaseMentorApplicationData(BaseModel):
     other_questions: Union[str, None] = Field(None, max_length=2048)
 
 
+Hour = Annotated[int, Field(ge=7, lt=24)]
+
+
+class BaseVolunteerApplicationData(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True, str_max_length=1024)
+
+    pronouns: list[str] = []
+    ethnicity: str
+    is_18_older: bool
+    school: str
+    education_level: str
+    major: str
+    applied_before: bool
+    frq_volunteer: str = Field(max_length=2048)
+    frq_utensil: str = Field(max_length=2048)
+    allergies: Union[str, None] = Field(None, max_length=2048)
+    extra_questions: Union[str, None] = Field(None, max_length=2048)
+
+    friday_availability: list[Hour] = []
+    saturday_availability: list[Hour] = []
+    sunday_availability: list[Hour] = []
+
+
 class RawHackerApplicationData(BaseApplicationData):
     """Expected to be sent by the form on the site."""
 
@@ -114,10 +124,12 @@ class RawMentorApplicationData(BaseMentorApplicationData):
     application_type: Literal["Mentor"]
 
 
-class RawVolunteerApplicationData(VolunteerApplicationData):
+class RawVolunteerApplicationData(BaseVolunteerApplicationData):
+    """Expected to be sent by the volunteer form on the site."""
+
     first_name: str
     last_name: str
-    resume: Union[UploadFile, None] = None
+    resume: None = None  # to simplify usage of union
     application_type: Literal["Volunteer"]
 
 
@@ -145,12 +157,10 @@ class ProcessedMentorApplicationData(BaseMentorApplicationData):
         return val
 
 
-class ProcessedVolunteerData(BaseVolunteerApplicationData):
+class ProcessedVolunteerApplication(BaseVolunteerApplicationData):
+    # TODO: specify common attributes in mixin
     submission_time: datetime
     reviews: list[Review] = []
-    friday_availability: dict[str, bool]
-    saturday_availability: dict[str, bool]
-    sunday_availability: dict[str, bool]
 
 
 # To add more discriminating values, add a string
@@ -177,7 +187,7 @@ ProcessedApplicationDataUnion = Annotated[
     Union[
         Annotated[ProcessedHackerApplicationData, Tag("hacker")],
         Annotated[ProcessedMentorApplicationData, Tag("mentor")],
-        Annotated[ProcessedVolunteerData, Tag("volunteer")],
+        Annotated[ProcessedVolunteerApplication, Tag("volunteer")],
     ],
     Discriminator(get_discriminator_value),
 ]

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -159,6 +159,7 @@ class ProcessedMentorApplicationData(BaseMentorApplicationData):
             return str(val)
         return val
 
+
 class ProcessedVolunteerApplication(BaseVolunteerApplicationData):
     # TODO: specify common attributes in mixin
     email: EmailStr

--- a/apps/api/src/models/user_record.py
+++ b/apps/api/src/models/user_record.py
@@ -4,10 +4,7 @@ from typing import Annotated, Union
 from pydantic import AfterValidator, Field
 from typing_extensions import TypeAlias
 
-from models.ApplicationData import (
-    Decision,
-    ProcessedApplicationDataUnion,
-)
+from models.ApplicationData import Decision, ProcessedApplicationDataUnion
 from services.mongodb_handler import BaseRecord
 
 

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -187,6 +187,7 @@ async def _apply_flow(
         {
             **raw_app_data_dump,
             "resume_url": resume_url,
+            "email": user.email,
             "submission_time": now,
         }
     )

--- a/apps/api/tests/test_user_volunteer_apply.py
+++ b/apps/api/tests/test_user_volunteer_apply.py
@@ -171,7 +171,7 @@ def test_volunteer_apply_with_confirmation_email_issue_causes_500(
 def test_volunteer_application_data_is_bson_encodable() -> None:
     """Test that application data model can be encoded into BSON to store in MongoDB."""
     encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
-    assert len(encoded) == 411
+    assert len(encoded) == 437
 
 
 def test_volunteer_past_deadline_causes_403() -> None:

--- a/apps/api/tests/test_user_volunteer_apply.py
+++ b/apps/api/tests/test_user_volunteer_apply.py
@@ -5,8 +5,8 @@ import bson
 from fastapi import FastAPI
 
 from auth.user_identity import NativeUser, UserTestClient
-from models.ApplicationData import ProcessedVolunteerData
-from models.user_record import Applicant, Status, Role
+from models.ApplicationData import ProcessedVolunteerApplication
+from models.user_record import Applicant, Role, Status
 from routers import user
 from services.mongodb_handler import Collection
 
@@ -22,7 +22,7 @@ USER_PKFIRE = NativeUser(
     affiliations=["pkfire"],
 )
 
-BASE_APPLICATION = {
+SAMPLE_APPLICATION = {
     "first_name": "pk",
     "last_name": "fire",
     "ethnicity": "E#",
@@ -36,23 +36,16 @@ BASE_APPLICATION = {
     "frq_utensil": "",
     "other_questions": "",
     "application_type": "Volunteer",
-}
-
-SAMPLE_APPLICATION = {
-    **BASE_APPLICATION,
-    "friday_availability": "{}",
-    "saturday_availability": "{}",
-    "sunday_availability": "{}",
+    "friday_availability": ["12", "13"],
+    "saturday_availability": ["14", "18"],
+    "sunday_availability": ["9", "10"],
 }
 
 SAMPLE_SUBMISSION_TIME = datetime(2024, 1, 12, 8, 1, 21, tzinfo=timezone.utc)
 SAMPLE_VERDICT_TIME = None
 
-EXPECTED_APPLICATION_DATA = ProcessedVolunteerData(
-    **BASE_APPLICATION,  # type: ignore[arg-type]
-    friday_availability={},
-    saturday_availability={},
-    sunday_availability={},
+EXPECTED_APPLICATION_DATA = ProcessedVolunteerApplication(
+    **SAMPLE_APPLICATION,  # type: ignore[arg-type]
     submission_time=SAMPLE_SUBMISSION_TIME,
     verdict_time=SAMPLE_VERDICT_TIME,
 )
@@ -89,7 +82,9 @@ def test_volunteer_apply_successfully(
     mock_mongodb_handler_retrieve_one.return_value = None
     mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
     mock_is_past_deadline.return_value = False
+
     res = client.post("/volunteer", data=SAMPLE_APPLICATION)
+    assert res.status_code == 201
 
     mock_mongodb_handler_update_one.assert_awaited_once_with(
         Collection.USERS,
@@ -100,47 +95,6 @@ def test_volunteer_apply_successfully(
     mock_send_application_confirmation_email.assert_awaited_once_with(
         USER_EMAIL, EXPECTED_USER, Role.VOLUNTEER
     )
-    assert res.status_code == 201
-
-
-@patch("utils.email_handler.send_application_confirmation_email", autospec=True)
-@patch("services.mongodb_handler.update_one", autospec=True)
-@patch("routers.user._is_past_deadline", autospec=True)
-@patch("routers.user.datetime", autospec=True)
-@patch("services.mongodb_handler.retrieve_one", autospec=True)
-def test_volunteer_apply_with_non_empty_availability(
-    mock_mongodb_handler_retrieve_one: AsyncMock,
-    mock_datetime: Mock,
-    mock_is_past_deadline: Mock,
-    mock_mongodb_handler_update_one: AsyncMock,
-    mock_send_application_confirmation_email: AsyncMock,
-) -> None:
-    """Testing the correctness of volunteer availabilities."""
-    mock_mongodb_handler_retrieve_one.return_value = None
-    mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
-    mock_is_past_deadline.return_value = False
-    new_app = SAMPLE_APPLICATION.copy()
-    new_app["friday_availability"] = '{"5PM": true, "6PM": false}'
-    res = client.post("/volunteer", data=new_app)
-
-    new_expected = EXPECTED_USER.model_dump()
-
-    new_expected["application_data"]["friday_availability"] = {
-        "5PM": True,
-        "6PM": False,
-    }
-
-    mock_mongodb_handler_update_one.assert_awaited_once_with(
-        Collection.USERS,
-        {"_id": EXPECTED_USER.uid},
-        new_expected,
-        upsert=True,
-    )
-
-    mock_send_application_confirmation_email.assert_awaited_once_with(
-        USER_EMAIL, Applicant(**new_expected), Role.VOLUNTEER
-    )
-    assert res.status_code == 201
 
 
 @patch("routers.user._is_past_deadline", autospec=True)
@@ -157,30 +111,9 @@ def test_volunteer_apply_with_invalid_availability_causes_422(
     mock_mongodb_handler_retrieve_one.return_value = None
 
     bad_application = SAMPLE_APPLICATION.copy()
-    bad_application["friday_availability"] = "<3"
+    bad_application["friday_availability"] = ["24"]
     res = client.post("/volunteer", data=bad_application)
 
-    assert res.status_code == 422
-
-
-@patch("routers.user._is_past_deadline", autospec=True)
-@patch("routers.user.datetime", autospec=True)
-@patch("services.mongodb_handler.retrieve_one", autospec=True)
-def test_volunteer_apply_with_invalid_application_type_causes_422(
-    mock_mongodb_handler_retrieve_one: AsyncMock,
-    mock_datetime: Mock,
-    mock_is_past_deadline: Mock,
-) -> None:
-    """Test that applying with invalid data is unprocessable."""
-    mock_datetime.now.return_value = SAMPLE_SUBMISSION_TIME
-    mock_is_past_deadline.return_value = False
-    mock_mongodb_handler_retrieve_one.return_value = None
-
-    bad_application = SAMPLE_APPLICATION.copy()
-    bad_application["application_type"] = "<3"
-    res = client.post("/volunteer", data=bad_application)
-
-    mock_mongodb_handler_retrieve_one.assert_not_called()
     assert res.status_code == 422
 
 
@@ -195,19 +128,6 @@ def test_volunteer_when_user_exists_causes_400(
     }
     res = client.post("/volunteer", data=SAMPLE_APPLICATION)
     assert res.status_code == 400
-
-
-@patch("services.mongodb_handler.retrieve_one", autospec=True)
-def test_volunteer_with_missing_data_causes_422(
-    mock_mongodb_handler_retrieve_one: AsyncMock,
-) -> None:
-    """Test that submitting volunteer form with missing data causes 422."""
-    wrong_app = SAMPLE_APPLICATION.copy()
-    wrong_app.pop("friday_availability", None)
-    res = client.post("/volunteer", data=wrong_app)
-
-    mock_mongodb_handler_retrieve_one.assert_not_called()
-    assert res.status_code == 422
 
 
 @patch("utils.email_handler.send_application_confirmation_email", autospec=True)
@@ -250,7 +170,7 @@ def test_volunteer_apply_with_confirmation_email_issue_causes_500(
 def test_volunteer_application_data_is_bson_encodable() -> None:
     """Test that application data model can be encoded into BSON to store in MongoDB."""
     encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
-    assert len(encoded) == 369
+    assert len(encoded) == 411
 
 
 def test_volunteer_past_deadline_causes_403() -> None:


### PR DESCRIPTION
As part of #477, simplifying the data processing for volunteer availability to remove unnecessary manual validation and make it easier to use in the future.

Previous data format
```json
	"friday_availability": {
		"11PM": false,
		"10PM": false,
		"9PM": false,
		"8PM": false,
		"7PM": false,
		"6PM": false,
		"5PM": true,
		"4PM": false,
		"3PM": false,
		"2PM": false,
		"1PM": true,
		"12PM": false,
		"11AM": true,
		"10AM": false,
		"9AM": false,
		"8AM": false,
		"7AM": false
	},

```

New data format
```json
	"friday_availability": [11, 13, 17],
```

### Changes
- Simplify data handling for volunteer time slots with name-shared input
  - Works like multi-select checkboxes and validated as a list of values
  - Provide list of numeric hours instead of mapping from 12-hour label
- Revert complications to apply flow while adding extraneous validation in #474
- Fix typo with `$exists` selector for checking already applied (described in #466)
- Extract global variable for fields supporting "other" values

### Testing
1. Run all development servers including the local database
2. Temporarily disable emails or use the dev mock being added in #465
3. For each type of applicant (Hacker, Mentor, Volunteer), impersonate a new user and complete an application
4. Observe the data is generally processed as expected (besides known bugs)
5. Check the database for the new entries and confirm the volunteer availability looks as expected