### PR TITLE
Refactor user roles from admin site to main site

### DIFF
--- a/apps/api/src/models/user_record.py
+++ b/apps/api/src/models/user_record.py
@@ -11,7 +11,7 @@ from services.mongodb_handler import BaseRecord
 class Role(str, Enum):
     """
     Possible roles of organizers and participants.
-    The values are the display labels to be shown on the Admin site.
+    The values are the display labels to be shown throughout the site.
     """
 
     APPLICANT = "Applicant"

--- a/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
@@ -9,6 +9,8 @@ import ReturnHome from "./components/ReturnHome";
 import VerticalTimeline from "./components/timeline/VerticalTimeline";
 import BackgroundStars from "./components/BackgroundStars";
 
+// TODO: use common Status enum from userRecord.ts
+
 export const enum PortalStatus {
 	pending = "PENDING_REVIEW",
 	reviewed = "REVIEWED",

--- a/apps/site/src/app/admin/applicants/[uid]/components/ApplicantActions.tsx
+++ b/apps/site/src/app/admin/applicants/[uid]/components/ApplicantActions.tsx
@@ -4,9 +4,10 @@ import ButtonDropdown, {
 	ButtonDropdownProps,
 } from "@cloudscape-design/components/button-dropdown";
 
-import { Decision, submitReview, Uid } from "@/lib/admin/useApplicant";
-import UserContext from "@/lib/admin/UserContext";
 import { isReviewer } from "@/lib/admin/authorization";
+import { submitReview } from "@/lib/admin/useApplicant";
+import UserContext from "@/lib/admin/UserContext";
+import { Decision, Uid } from "@/lib/userRecord";
 
 interface ApplicantActionsProps {
 	applicant: Uid;

--- a/apps/site/src/app/admin/applicants/[uid]/components/ApplicationReviews.tsx
+++ b/apps/site/src/app/admin/applicants/[uid]/components/ApplicationReviews.tsx
@@ -1,8 +1,9 @@
 import { useContext } from "react";
 
 import ApplicantStatus from "@/app/admin/applicants/components/ApplicantStatus";
-import { Review, Uid } from "@/lib/admin/useApplicant";
+import { Review } from "@/lib/admin/useApplicant";
 import UserContext from "@/lib/admin/UserContext";
+import { Uid } from "@/lib/userRecord";
 
 interface ApplicationReviewsProps {
 	reviews: Review[];

--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -11,7 +11,7 @@ import {
 	ReviewStatus,
 	Status,
 	PostAcceptedStatus,
-} from "@/lib/admin/useApplicant";
+} from "@/lib/userRecord";
 
 import { StatusLabels } from "./ApplicantStatus";
 

--- a/apps/site/src/app/admin/applicants/components/ApplicantStatus.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantStatus.tsx
@@ -2,7 +2,7 @@ import StatusIndicator, {
 	StatusIndicatorProps,
 } from "@cloudscape-design/components/status-indicator";
 
-import { Status } from "@/lib/admin/useApplicant";
+import { Status } from "@/lib/userRecord";
 
 export const StatusLabels = {
 	[Status.accepted]: "accepted",

--- a/apps/site/src/app/admin/dashboard/components/ApplicantSummary.tsx
+++ b/apps/site/src/app/admin/dashboard/components/ApplicantSummary.tsx
@@ -2,7 +2,7 @@ import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
 import PieChart from "@cloudscape-design/components/pie-chart";
 
-import { Status } from "@/lib/admin/useApplicant";
+import { Status } from "@/lib/userRecord";
 
 import useApplicantSummary from "./useApplicantSummary";
 

--- a/apps/site/src/app/admin/dashboard/components/HackerCount.tsx
+++ b/apps/site/src/app/admin/dashboard/components/HackerCount.tsx
@@ -3,7 +3,8 @@ import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 
-import useParticipants, { Role } from "@/lib/admin/useParticipants";
+import useParticipants from "@/lib/admin/useParticipants";
+import { ParticipantRole } from "@/lib/userRecord";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -16,7 +17,9 @@ function HackerCount() {
 	const { participants, loading } = useParticipants();
 
 	const checkedIn = participants
-		.filter((participant) => participant.roles.includes(Role.Applicant))
+		.filter((participant) =>
+			participant.roles.includes(ParticipantRole.Applicant),
+		)
 		.filter((participant) =>
 			participant.checkins.some(([datetime]) =>
 				FRIDAY.isSame(dayjs(datetime).tz(EVENT_TIMEZONE), "date"),

--- a/apps/site/src/app/admin/dashboard/components/useApplicantSummary.ts
+++ b/apps/site/src/app/admin/dashboard/components/useApplicantSummary.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import useSWR from "swr";
 
-import { Status } from "@/lib/admin/useApplicant";
+import { Status } from "@/lib/userRecord";
 
 type ApplicantSummary = Partial<Record<Status, number>>;
 

--- a/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
@@ -2,11 +2,25 @@ import { useContext } from "react";
 
 import Button from "@cloudscape-design/components/button";
 
+import { isCheckInLead } from "@/lib/admin/authorization";
 import UserContext from "@/lib/admin/UserContext";
-import { isCheckinLead, isNonHacker } from "@/lib/admin/authorization";
-import { ReviewStatus, Status } from "@/lib/admin/useApplicant";
 import { Participant } from "@/lib/admin/useParticipants";
+import { ParticipantRole, ReviewStatus, Status } from "@/lib/userRecord";
+
 import ParticipantActionPopover from "./ParticipantActionPopover";
+
+const NONHACKER_ROLES = [
+	ParticipantRole.Judge,
+	ParticipantRole.Sponsor,
+	ParticipantRole.Mentor,
+	ParticipantRole.Volunteer,
+	ParticipantRole.WorkshopLead,
+];
+
+// TODO: reexamine attendance confirmation process
+export function isNonHacker(roles: ReadonlyArray<ParticipantRole>) {
+	return roles.some((role) => NONHACKER_ROLES.includes(role));
+}
 
 interface ParticipantActionProps {
 	participant: Participant;
@@ -23,7 +37,7 @@ function ParticipantAction({
 }: ParticipantActionProps) {
 	const { roles } = useContext(UserContext);
 
-	const canPromote = isCheckinLead(roles);
+	const canPromote = isCheckInLead(roles);
 	const isWaiverSigned = participant.status === Status.signed;
 	const isAccepted = participant.status === Status.accepted;
 	const nonHacker = isNonHacker(participant.roles);

--- a/apps/site/src/app/admin/participants/components/ParticipantsFilters.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsFilters.tsx
@@ -15,8 +15,10 @@ import {
 	PostAcceptedStatus,
 	ReviewStatus,
 	Status,
-} from "@/lib/admin/useApplicant";
-import { StatusLabels } from "../../applicants/components/ApplicantStatus";
+} from "@/lib/userRecord";
+
+import { StatusLabels } from "@/app/admin/applicants/components/ApplicantStatus";
+
 import type { Options } from "./ParticipantsTable";
 
 interface ParticipantsFiltersProps {

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -11,7 +11,8 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table, { TableProps } from "@cloudscape-design/components/table";
 
 import ApplicantStatus from "@/app/admin/applicants/components/ApplicantStatus";
-import { Participant, Role } from "@/lib/admin/useParticipants";
+import { Participant } from "@/lib/admin/useParticipants";
+import { ParticipantRole } from "@/lib/userRecord";
 
 import CheckinDayIcon from "./CheckinDayIcon";
 import ParticipantAction from "./ParticipantAction";
@@ -103,7 +104,7 @@ function ParticipantsTable({
 		filterRole.length === 0 ||
 		filterRole
 			.map((r) => r.value)
-			.some((role) => p.roles.includes(role as Role));
+			.some((role) => p.roles.includes(role as ParticipantRole));
 	const matchesStatus = (p: Participant) =>
 		filterStatus.length === 0 ||
 		filterStatus.map((s) => s.value).includes(p.status);

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -1,31 +1,27 @@
-// TODO: refactor roles to enum somewhere else
-const MANAGER_ROLES = ["Director", "Reviewer", "Check-in Lead"];
-const NONHACKER_ROLES = [
-	"Judge",
-	"Sponsor",
-	"Mentor",
-	"Volunteer",
-	"Workshop Lead",
+import { AdminRole, Role } from "@/lib/userRecord";
+
+// TODO: reexamine waitlist release procedure: do check-in leads really need to be managers?
+const MANAGER_ROLES = [
+	AdminRole.Director,
+	AdminRole.Reviewer,
+	AdminRole.CheckInLead,
 ];
 
-export function isApplicationManager(roles: ReadonlyArray<string>) {
-	return roles.some((role) => MANAGER_ROLES.includes(role));
+export function isApplicationManager(roles: ReadonlyArray<Role>): boolean {
+	return MANAGER_ROLES.some((managerRole) => roles.includes(managerRole));
 }
 
 // Conceptually, an admin is just a Hack organizer
-export function hasAdminRole(role: ReadonlyArray<string>) {
-	return role.includes("Organizer");
+export function hasAdminRole(role: ReadonlyArray<Role>): boolean {
+	return role.includes(AdminRole.Organizer);
 }
 
-export function isCheckinLead(roles: ReadonlyArray<string>) {
-	return roles.includes("Director") || roles.includes("Check-in Lead");
+export function isCheckInLead(roles: ReadonlyArray<Role>): boolean {
+	return (
+		roles.includes(AdminRole.Director) || roles.includes(AdminRole.CheckInLead)
+	);
 }
 
-export function isReviewer(roles: ReadonlyArray<string>) {
-	return roles.includes("Reviewer");
-}
-
-// refactor: this function should be placed elsewhere later
-export function isNonHacker(roles: ReadonlyArray<string>) {
-	return roles.some((role) => NONHACKER_ROLES.includes(role));
+export function isReviewer(roles: ReadonlyArray<Role>): boolean {
+	return roles.includes(AdminRole.Reviewer);
 }

--- a/apps/site/src/lib/admin/useApplicant.ts
+++ b/apps/site/src/lib/admin/useApplicant.ts
@@ -1,13 +1,7 @@
 import axios from "axios";
 import useSWR from "swr";
 
-export type Uid = string;
-
-export enum Decision {
-	accepted = "ACCEPTED",
-	rejected = "REJECTED",
-	waitlisted = "WAITLISTED",
-}
+import { Decision, ParticipantRole, Status, Uid } from "@/lib/userRecord";
 
 export type Review = [string, Uid, Decision];
 
@@ -32,27 +26,11 @@ export interface ApplicationData {
 
 export type ApplicationQuestion = Exclude<keyof ApplicationData, "reviews">;
 
-export enum ReviewStatus {
-	pending = "PENDING_REVIEW",
-	reviewed = "REVIEWED",
-	released = "RELEASED",
-}
-
-export enum PostAcceptedStatus {
-	signed = "WAIVER_SIGNED",
-	confirmed = "CONFIRMED",
-	attending = "ATTENDING",
-	void = "VOID",
-}
-
-export const Status = { ...ReviewStatus, ...Decision, ...PostAcceptedStatus };
-export type Status = ReviewStatus | Decision | PostAcceptedStatus;
-
 export interface Applicant {
 	_id: Uid;
 	first_name: string;
 	last_name: string;
-	roles: ReadonlyArray<string>;
+	roles: ReadonlyArray<ParticipantRole>;
 	status: Status;
 	application_data: ApplicationData;
 }

--- a/apps/site/src/lib/admin/useApplicants.ts
+++ b/apps/site/src/lib/admin/useApplicants.ts
@@ -1,14 +1,14 @@
 import axios from "axios";
 import useSWR from "swr";
 
-import { Status } from "./useApplicant";
+import { Decision, Status } from "@/lib/userRecord";
 
 export interface ApplicantSummary {
 	_id: string;
 	first_name: string;
 	last_name: string;
 	status: Status;
-	decision: Status | null;
+	decision: Decision | null;
 	application_data: {
 		school: string;
 		submission_time: string;

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -1,21 +1,7 @@
 import axios from "axios";
 import useSWR from "swr";
 
-import { Status, Uid } from "@/lib/admin/useApplicant";
-
-// These should match `user_record.Role` in the API
-// TODO: move to common `userRecord` file
-export const enum Role {
-	Director = "Director",
-	Organizer = "Organizer",
-	CheckInLead = "Check-in Lead",
-	Applicant = "Applicant",
-	Mentor = "Mentor",
-	Volunteer = "Volunteer",
-	Sponsor = "Sponsor",
-	Judge = "Judge",
-	WorkshopLead = "Workshop Lead",
-}
+import { ParticipantRole, Status, Uid } from "@/lib/userRecord";
 
 export type Checkin = [string, Uid];
 
@@ -23,7 +9,7 @@ export interface Participant {
 	_id: Uid;
 	first_name: string;
 	last_name: string;
-	roles: ReadonlyArray<Role>;
+	roles: ReadonlyArray<ParticipantRole>;
 	checkins: Checkin[];
 	status: Status;
 	badge_number: string | null;

--- a/apps/site/src/lib/userRecord.ts
+++ b/apps/site/src/lib/userRecord.ts
@@ -1,0 +1,54 @@
+/** Represents a UID of a user record, just an alias for string. */
+export type Uid = string;
+
+// Note: role labels should match `user_record.Role` in the API
+
+/** The possible roles of general participants. */
+export enum ParticipantRole {
+	Applicant = "Applicant",
+	Mentor = "Mentor",
+	Volunteer = "Volunteer",
+	Sponsor = "Sponsor",
+	Judge = "Judge",
+	WorkshopLead = "Workshop Lead",
+}
+
+/** The possible roles of admin users (organizers). */
+export enum AdminRole {
+	Organizer = "Organizer",
+	Reviewer = "Reviewer",
+	CheckInLead = "Check-in Lead",
+	Director = "Director",
+}
+
+/** All of the different possible user roles. */
+export type Role = ParticipantRole | AdminRole;
+
+/**
+ * The decision for an applicant.
+ * An applicant's decision becomes their status when released.
+ */
+export enum Decision {
+	accepted = "ACCEPTED",
+	rejected = "REJECTED",
+	waitlisted = "WAITLISTED",
+}
+
+/** The possible statuses for an applicant without a released decision. */
+export enum ReviewStatus {
+	pending = "PENDING_REVIEW",
+	reviewed = "REVIEWED",
+	released = "RELEASED",
+}
+
+/** The possible status after an applicant has been accepted. */
+export enum PostAcceptedStatus {
+	signed = "WAIVER_SIGNED",
+	confirmed = "CONFIRMED",
+	attending = "ATTENDING",
+	void = "VOID",
+}
+
+/** All of the different possible status values. */
+export const Status = { ...ReviewStatus, ...Decision, ...PostAcceptedStatus };
+export type Status = ReviewStatus | Decision | PostAcceptedStatus;

--- a/apps/site/src/lib/utils/getUserIdentity.ts
+++ b/apps/site/src/lib/utils/getUserIdentity.ts
@@ -1,10 +1,12 @@
 import axios from "axios";
 
+import { Role, Uid } from "@/lib/userRecord";
+
 import api from "./api";
 
 export interface Identity {
-	uid: string | null;
-	roles: ReadonlyArray<string>;
+	uid: Uid | null;
+	roles: ReadonlyArray<Role>;
 	status: string | null;
 }
 


### PR DESCRIPTION
Using enums to represent the different possible user roles to have stronger named references.
Resolves #516. Will create a new issue about reorganizing how `Status` is used in the Applicant Portal.

#### Changes
- Create new enums for user roles for both the admin site and main site
- Move status enums from `useApplicant` to the new `userRecord.ts`
- Move `isNonHacker` check to `ParticipantAction`
- The Portal still needs to be updated to use the new common enums