### PR TITLE
Enable request memoization for `getUserIdentity`

### DIFF
--- a/apps/site/src/app/(main)/layout.tsx
+++ b/apps/site/src/app/(main)/layout.tsx
@@ -20,7 +20,6 @@ export default function Layout({ children }: PropsWithChildren) {
 			style={{ backgroundImage: `url(${stars.src})` }}
 			className="overflow-x-hidden bg-top bg-repeat-y bg-[length:100%]"
 		>
-			{/* reference: https://github.com/pmndrs/react-three-next */}
 			<NavbarParent />
 			{children}
 			<Footer />

--- a/apps/site/src/lib/utils/getUserIdentity.ts
+++ b/apps/site/src/lib/utils/getUserIdentity.ts
@@ -1,3 +1,6 @@
+import { cache } from "react";
+import { cookies } from "next/headers";
+
 import axios from "axios";
 
 import { Role, Uid } from "@/lib/userRecord";
@@ -10,7 +13,13 @@ export interface Identity {
 	status: string | null;
 }
 
-export default async function getUserIdentity(): Promise<Identity> {
+async function getUserIdentity(): Promise<Identity> {
+	// Indicate to Next.js that components using this function need to be dynamically rendered.
+	// Otherwise, Next.js will try to use static rendering and error. See #168 for explanation.
+	// This might be removable when upgrading to `dynamicIO` in Next.js 15
+	// The cookies will actually be added by a request interceptor on the Axios instance
+	void cookies();
+
 	try {
 		const identity = await api.get<Identity>("/user/me");
 		return identity.data;
@@ -24,3 +33,7 @@ export default async function getUserIdentity(): Promise<Identity> {
 		return { uid: null, roles: [], status: null };
 	}
 }
+
+// Use request memoization so that the API request is made only once when React renders the tree
+// Axios uses XHR by default internally unlike `fetch` which would be automatically cached
+export default cache(getUserIdentity);


### PR DESCRIPTION
Resolves #524 and fixes #168.

#### Changes
- Wrap function in [RSC `cache`](https://react.dev/reference/react/cache) so the API request is made only once each time the page is rendered (for each server request)
  - Previously, the request might be unnecessarily made multiple times
- Call `cookies()` inside the function to indicate to Next.js that pages using said function must be [dynamically rendered](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering)
  - In the future, [`dynamicIO` in Next.js 15](https://nextjs.org/docs/app/api-reference/config/next-config-js/dynamicIO) might work better instead
- Remove stray comment in `app/(main)/layout.tsx`

#### Testing
1. Start the local development servers
2. Navigate to `/apply` in a web browser
3. Observe in the FastAPI logs that the `/user/me` endpoint is accessed only one time rather than three times
4. Reload the same page
5. Observe the `/user/me` endpoint is accessed again, demonstrating that the cache is per request