### PR TITLE
[Admin] Set hacker score thresholds

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -175,8 +175,8 @@ async def submit_review(
 @router.post("/set-thresholds")
 async def set_hacker_score_thresholds(
     user: Annotated[User, Depends(require_manager)],
-    accept: float = Body(),
-    waitlist: float = Body(),
+    accept: str = Body(),
+    waitlist: str = Body(),
 ) -> None:
     """
     Sets accepted, waitlisted, and implicitly rejected score thresholds.
@@ -184,11 +184,17 @@ async def set_hacker_score_thresholds(
     """
     log.info("%s changed thresholds: Accept-%f | Waitlist-%f", user, accept, waitlist)
 
+    update_query = {}
+    if accept:
+        update_query["accept"] = float(accept)
+    if waitlist:
+        update_query["waitlist"] = float(waitlist)
+
     try:
         await mongodb_handler.raw_update_one(
             Collection.SETTINGS,
             {"_id": "hacker_score_thresholds"},
-            {"$set": {"accept": accept, "waitlist": waitlist}},
+            {"$set": update_query},
             upsert=True,
         )
     except RuntimeError:

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -327,10 +327,12 @@ def test_set_thresholds_with_empty_string_correctly(
     mock_mongodb_handler_raw_update_one: AsyncMock,
     mock_mongodb_handler_retrieve_one: AsyncMock,
 ) -> None:
-    """Test that the /set-thresholds route returns correctly"""
+    """Test that the /set-thresholds route returns correctly with -1"""
     mock_mongodb_handler_retrieve_one.return_value = REVIEWER_IDENTITY
 
-    res = reviewer_client.post("/set-thresholds", json={"accept": "12", "waitlist": ""})
+    res = reviewer_client.post(
+        "/set-thresholds", json={"accept": "12", "waitlist": "-1"}
+    )
 
     assert res.status_code == 200
     mock_mongodb_handler_raw_update_one.assert_awaited_once_with(

--- a/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
@@ -19,10 +19,13 @@ function HackerThresholdInputs() {
 	const [status, setStatus] = useState("");
 
 	async function submitThresholds() {
+		const sentAcceptValue = acceptValue ? acceptValue : -1;
+		const sentWaitlistValue = waitlistValue ? waitlistValue : -1;
+
 		await axios
 			.post("/api/admin/set-thresholds", {
-				accept: acceptValue,
-				waitlist: waitlistValue,
+				accept: sentAcceptValue,
+				waitlist: sentWaitlistValue,
 			})
 			.then((response) => {
 				// TODO: Add flashbar or modal to show post status

--- a/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
@@ -12,6 +12,7 @@ import useHackerThresholds from "@/lib/admin/useHackerThresholds";
 
 function HackerThresholdInputs() {
 	const { thresholds } = useHackerThresholds();
+
 	const [acceptValue, setAcceptValue] = useState("");
 	const [waitlistValue, setWaitlistValue] = useState("");
 
@@ -73,7 +74,11 @@ function HackerThresholdInputs() {
 			<Button variant="primary" onClick={submitThresholds}>
 				Update Thresholds
 			</Button>
-			{status ? <Box variant="awsui-key-label">{status}</Box> : null}
+			{status ? (
+				<Box variant="awsui-key-label" color="text-status-warning">
+					{status}
+				</Box>
+			) : null}
 		</SpaceBetween>
 	);
 }

--- a/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerThresholdInputs.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import axios from "axios";
+
+import {
+	Box,
+	Button,
+	Input,
+	SpaceBetween,
+} from "@cloudscape-design/components";
+
+import useHackerThresholds from "@/lib/admin/useHackerThresholds";
+
+function HackerThresholdInputs() {
+	const { thresholds } = useHackerThresholds();
+	const [acceptValue, setAcceptValue] = useState("");
+	const [waitlistValue, setWaitlistValue] = useState("");
+
+	const [status, setStatus] = useState("");
+
+	async function submitThresholds() {
+		await axios
+			.post("/api/admin/set-thresholds", {
+				accept: acceptValue,
+				waitlist: waitlistValue,
+			})
+			.then((response) => {
+				// TODO: Add flashbar or modal to show post status
+				if (response.status === 200) {
+					setStatus(
+						"Successfully updated thresholds. Reload to see changes to applicants.",
+					);
+				} else {
+					setStatus("Failed to update thresholds");
+				}
+			});
+	}
+
+	return (
+		<SpaceBetween direction="vertical" size="xs">
+			{thresholds && (
+				<>
+					<Box variant="awsui-key-label">
+						Current Accept Threshold: {thresholds.accept}
+					</Box>
+					<Box variant="awsui-key-label">
+						Current Waitlist Threshold: {thresholds.waitlist}
+					</Box>
+				</>
+			)}
+			<Box variant="awsui-key-label">Accept Threshold</Box>
+			<Input
+				onChange={({ detail }) => setAcceptValue(detail.value)}
+				value={acceptValue}
+				type="number"
+				inputMode="decimal"
+				placeholder="Accept Threshold"
+				step={0.1}
+			/>
+			<Box variant="awsui-key-label">Waitlist Threshold</Box>
+			<Input
+				onChange={({ detail }) => setWaitlistValue(detail.value)}
+				value={waitlistValue}
+				type="number"
+				inputMode="decimal"
+				placeholder="Waitlist Threshold"
+				step={0.1}
+			/>
+			<Box variant="p">
+				Any score under{" "}
+				{waitlistValue ? waitlistValue : "the waitlist threshold"} will be
+				rejected
+			</Box>
+			<Button variant="primary" onClick={submitThresholds}>
+				Update Thresholds
+			</Button>
+			{status ? <Box variant="awsui-key-label">{status}</Box> : null}
+		</SpaceBetween>
+	);
+}
+
+export default HackerThresholdInputs;

--- a/apps/site/src/app/admin/applicants/hackers/HackerApplicants.tsx
+++ b/apps/site/src/app/admin/applicants/hackers/HackerApplicants.tsx
@@ -19,6 +19,7 @@ import ApplicantStatus from "../components/ApplicantStatus";
 
 import UserContext from "@/lib/admin/UserContext";
 import { isApplicationManager } from "@/lib/admin/authorization";
+import HackerThresholdInputs from "../components/HackerThresholdInputs";
 
 function HackerApplicants() {
 	const router = useRouter();
@@ -110,7 +111,11 @@ function HackerApplicants() {
 				/>
 			}
 			empty={emptyContent}
-			header={<Header counter={counter}>Applicants</Header>}
+			header={
+				<Header counter={counter} actions={<HackerThresholdInputs />}>
+					Applicants
+				</Header>
+			}
 		/>
 	);
 }

--- a/apps/site/src/lib/admin/useHackerThresholds.ts
+++ b/apps/site/src/lib/admin/useHackerThresholds.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+import useSWR from "swr";
+
+export interface ScoreThresholds {
+	_id: string;
+	accept: number;
+	waitlist: number;
+}
+
+const fetcher = async (url: string) => {
+	const res = await axios.get<ScoreThresholds>(url);
+	return res.data;
+};
+
+function useHackerThresholds() {
+	const { data, error, isLoading } = useSWR<ScoreThresholds>(
+		"/api/admin/get-thresholds",
+		fetcher,
+	);
+
+	return { thresholds: data, loading: isLoading, error };
+}
+
+export default useHackerThresholds;


### PR DESCRIPTION
Part of #510

- Insert document in MongoDB under `settings` collection similar to the following:
```
{
    _id: 'hacker_score_thresholds',
    accept: 8,
    waitlist: 5
}
```
- Insert document in MongoDB under `users` collection similar to the following:
```
{
    _id: 'edu.uci.app22',
    application_data: {
        pronouns: [
            'he',
            'she'
        ],
        ethnicity: 'Two-or-more',
        is_18_older: false,
        school: 'UC San Diego',
        education_level: 'third-year-undergrad',
        major: 'Software Engineering',
        is_first_hackathon: false,
        linkedin: null,
        portfolio: null,
        frq_change: 'dsad',
        frq_video_game: 'dsa',
        email: 'dev@irvinehacks.com',
        resume_url: null,
        submission_time: ISODate('2024-12-20T17:32:59.973Z'),
        reviews: [
            [
                ISODate('2024-12-20T17:41:22.634Z'),
                'edu.uci.ian4',
                4
            ],
            [
                ISODate('2024-12-20T17:42:01.098Z'),
                'edu.uci.ian5',
                10
            ]
        ]
    },
    first_name: 'dwa',
    last_name: 'sds',
    roles: [
        'Applicant',
        'Hacker'
    ],
    status: 'ACCEPTED'
}
```

- Navigate to `/admin/applicants/hackers`
- Change the thresholds in the top right, reload, and see a change in the applicant's decision