### PR TITLE
Reorganize search params for server components

### DIFF
--- a/apps/site/src/app/(main)/apply/Hacker.tsx
+++ b/apps/site/src/app/(main)/apply/Hacker.tsx
@@ -6,7 +6,7 @@ export const revalidate = 60;
 export default async function Hacker({
 	searchParams,
 }: {
-	searchParams?: {
+	searchParams: {
 		prefaceAccepted?: string;
 	};
 }) {

--- a/apps/site/src/app/(main)/guest-login/GuestLogin.tsx
+++ b/apps/site/src/app/(main)/guest-login/GuestLogin.tsx
@@ -7,6 +7,7 @@ async function GuestLogin({
 	searchParams,
 }: {
 	searchParams?: {
+		email?: string;
 		return_to?: string;
 	};
 }) {
@@ -20,7 +21,10 @@ async function GuestLogin({
 			<h1 className="font-display text-3xl md:text-5xl mb-20">
 				Enter Passphrase
 			</h1>
-			<GuestLoginVerificationForm />
+			<GuestLoginVerificationForm
+				email={searchParams?.email}
+				return_to={searchParams?.return_to}
+			/>
 		</div>
 	);
 }

--- a/apps/site/src/app/(main)/guest-login/GuestLogin.tsx
+++ b/apps/site/src/app/(main)/guest-login/GuestLogin.tsx
@@ -6,14 +6,16 @@ import getUserIdentity from "@/lib/utils/getUserIdentity";
 async function GuestLogin({
 	searchParams,
 }: {
-	searchParams?: {
+	searchParams: {
 		email?: string;
 		return_to?: string;
 	};
 }) {
+	const { email, return_to } = searchParams;
+
 	const identity = await getUserIdentity();
 	if (identity.uid !== null) {
-		redirect(searchParams?.return_to ?? "/portal");
+		redirect(return_to ?? "/portal");
 	}
 
 	return (
@@ -21,10 +23,7 @@ async function GuestLogin({
 			<h1 className="font-display text-3xl md:text-5xl mb-20">
 				Enter Passphrase
 			</h1>
-			<GuestLoginVerificationForm
-				email={searchParams?.email}
-				return_to={searchParams?.return_to}
-			/>
+			<GuestLoginVerificationForm email={email} return_to={return_to} />
 		</div>
 	);
 }

--- a/apps/site/src/app/(main)/guest-login/components/GuestLoginVerificationForm.tsx
+++ b/apps/site/src/app/(main)/guest-login/components/GuestLoginVerificationForm.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
 import clsx from "clsx";
 
 import ValidatingForm from "@/lib/components/ValidatingForm/ValidatingForm";
@@ -11,17 +8,19 @@ import styles from "@/lib/components/ValidatingForm/ValidatingForm.module.scss";
 const VERIFICATION_PATH = "/api/guest/verify";
 const PASSPHRASE_REGEX = /\w+-\w+-\w+-\w+/;
 
-export default function GuestLoginVerificationForm() {
-	const searchParams = useSearchParams();
-	const email = searchParams.get("email");
-	const return_to = searchParams.get("return_to");
-
+export default function GuestLoginVerificationForm({
+	email,
+	return_to,
+}: {
+	email?: string;
+	return_to?: string;
+}) {
 	if (!email) {
 		return <p>Error: email was not provided</p>;
 	}
 
 	const newSearchParams = new URLSearchParams();
-	if (return_to !== null) {
+	if (return_to) {
 		newSearchParams.append("return_to", return_to);
 	}
 

--- a/apps/site/src/app/(main)/login/Login.tsx
+++ b/apps/site/src/app/(main)/login/Login.tsx
@@ -5,13 +5,15 @@ import LoginForm from "./components/LoginForm";
 async function Login({
 	searchParams,
 }: {
-	searchParams?: {
+	searchParams: {
 		return_to?: string;
 	};
 }) {
+	const { return_to } = searchParams;
+
 	const identity = await getUserIdentity();
 	if (identity.uid !== null) {
-		redirect(searchParams?.return_to ?? "/portal");
+		redirect(return_to ?? "/portal");
 	}
 
 	return (
@@ -19,7 +21,7 @@ async function Login({
 			<h1 className="font-display text-3xl md:text-5xl mb-20">
 				Login to Portal
 			</h1>
-			<LoginForm return_to={searchParams?.return_to} />
+			<LoginForm return_to={return_to} />
 		</div>
 	);
 }

--- a/apps/site/src/app/(main)/mentor/Mentor.tsx
+++ b/apps/site/src/app/(main)/mentor/Mentor.tsx
@@ -6,7 +6,7 @@ export const revalidate = 60;
 export default async function Mentor({
 	searchParams,
 }: {
-	searchParams?: {
+	searchParams: {
 		prefaceAccepted?: string;
 	};
 }) {

--- a/apps/site/src/app/(main)/volunteer/Volunteer.tsx
+++ b/apps/site/src/app/(main)/volunteer/Volunteer.tsx
@@ -6,7 +6,7 @@ export const revalidate = 60;
 export default async function Volunteer({
 	searchParams,
 }: {
-	searchParams?: {
+	searchParams: {
 		prefaceAccepted?: string;
 	};
 }) {

--- a/apps/site/src/lib/components/forms/shared/ApplicationFlow.tsx
+++ b/apps/site/src/lib/components/forms/shared/ApplicationFlow.tsx
@@ -12,7 +12,7 @@ import getUserIdentity from "@/lib/utils/getUserIdentity";
 export const revalidate = 60;
 
 interface ApplicationFlowProps {
-	searchParams?: {
+	searchParams: {
 		prefaceAccepted?: string;
 	};
 	applicationType: "Hacker" | "Mentor" | "Volunteer";
@@ -25,7 +25,7 @@ export default async function ApplicationFlow({
 	applicationURL,
 	children,
 }: ApplicationFlowProps & PropsWithChildren) {
-	const hasAcceptedQueryParam = searchParams?.prefaceAccepted === "true";
+	const hasAcceptedQueryParam = searchParams.prefaceAccepted === "true";
 	const identity = await getUserIdentity();
 
 	if (identity.status !== null) {


### PR DESCRIPTION
## Changes
- Removes the use of `useSearchParams` in `GuestLoginVerificationForm`
- Uses `searchParams` from `GuestLogin` and passes `searchParams` as props to `GuestLoginVerificationForm`
- These changes allow for `GuestLoginVerificationForm` to no longer need to be a client component
- Unmark `searchParams` as optional as Next.js always provides this to page components
- Unpacks `searchParams` before using query parameters

Closes #521 and unblocks #403 to allow upgrading to Next.js 14.