### PR TITLE
Safari UI Fixes

### DIFF
--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQ.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQ.tsx
@@ -28,7 +28,7 @@ const FAQ = async () => {
 
 	return (
 		<section className="flex justify-center bg-no-repeat bg-cover bg-top mt-20 lg:mt-40">
-			<div className="relative flex flex-col w-5/6 pb-7 justify-center">
+			<div className="relative flex flex-col w-4/5 pb-7 justify-center">
 				<h2 className="my-6 font-display text-white text-4xl sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl text-center">
 					Frequently Asked Questions
 				</h2>

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQ.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQ.tsx
@@ -28,7 +28,7 @@ const FAQ = async () => {
 
 	return (
 		<section className="flex justify-center bg-no-repeat bg-cover bg-top mt-20 lg:mt-40">
-			<div className="relative flex flex-col w-4/5 pb-7 justify-center">
+			<div className="relative flex flex-col w-5/6 pb-7 justify-center">
 				<h2 className="my-6 font-display text-white text-4xl sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl text-center">
 					Frequently Asked Questions
 				</h2>

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
@@ -106,7 +106,7 @@ const FAQAccordionDesktop: React.FC<FAQAccordion> = ({ faq }) => {
 											setPage1Selected(true);
 										}}
 										className={
-											"w-[100px] absolute flex items-center mt-4 group hover:bg-white hover:text-black px-[3px] xl:mt-4 duration-300"
+											"w-[100px] xl:w-[105px] absolute flex items-center mt-4 group hover:bg-white hover:text-black px-[3px] xl:mt-4 duration-300"
 										}
 									>
 										<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
@@ -36,7 +36,7 @@ const FAQAccordionDesktop: React.FC<FAQAccordion> = ({ faq }) => {
 								inverted
 							/>
 
-							<p className="ms-2">{focusedQuestion?.answer}</p>
+							<div className="ms-2">{focusedQuestion?.answer}</div>
 						</div>
 
 						<div className="absolute bottom-0">

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
@@ -49,84 +49,80 @@ const FAQAccordionDesktop: React.FC<FAQAccordion> = ({ faq }) => {
 							/>
 						</div>
 					</div>
+				) : page1Selected ? (
+					<div className="duration-300">
+						{faqGroup1.map((F) => (
+							<ListItemButton
+								key={F._key}
+								onClick={() => setFocusedQuestion(F)}
+								text={F.question}
+								inverted={false}
+								className="mb-0 py-[2px]"
+							/>
+						))}
+						<div className="flex justify-end w-full ms-3">
+							<button
+								type="button"
+								onClick={() => {
+									setPage1Selected(false);
+								}}
+								className={
+									"flex items-center opacity-100 hover:bg-white hover:text-black px-[3px] duration-300 group"
+								}
+							>
+								Page 1/2
+								<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
+								<TriangleIcon
+									className={
+										"ms-2 absolute hidden group-hover:block duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+									}
+									dark
+								/>
+								<TriangleIcon
+									className={
+										"ms-2 absolute group-hover:hidden duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+									}
+								/>
+							</button>
+						</div>
+					</div>
 				) : (
-					<>
-						{page1Selected ? (
-							<div className="duration-300">
-								{faqGroup1.map((F) => (
-									<ListItemButton
-										key={F._key}
-										onClick={() => setFocusedQuestion(F)}
-										text={F.question}
-										inverted={false}
-										className="mb-0 py-[2px]"
-									/>
-								))}
-								<div className="flex justify-end w-full ms-3">
-									<button
-										type="button"
-										onClick={() => {
-											setPage1Selected(false);
-										}}
-										className={
-											"flex items-center opacity-100 hover:bg-white hover:text-black px-[3px] duration-300 group"
-										}
-									>
-										Page 1/2
-										<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
-										<TriangleIcon
-											className={
-												"ms-2 absolute hidden group-hover:block duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
-											}
-											dark
-										/>
-										<TriangleIcon
-											className={
-												"ms-2 absolute group-hover:hidden duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
-											}
-										/>
-									</button>
-								</div>
-							</div>
-						) : (
-							<div className="duration-300">
-								{faqGroup2.map((F) => (
-									<ListItemButton
-										key={F._key}
-										onClick={() => setFocusedQuestion(F)}
-										text={F.question}
-										inverted={false}
-										className="mb-0 py-[2px]"
-									/>
-								))}
-								<div className="flex justify-end ms-3 w-full">
-									<button
-										type="button"
-										onClick={() => {
-											setPage1Selected(true);
-										}}
-										className={
-											"w-[100px] xl:w-[105px] absolute flex items-center mt-4 group hover:bg-white hover:text-black px-[3px] xl:mt-4 duration-300"
-										}
-									>
-										<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
-										<TriangleIcon
-											className={
-												"ms-2 absolute hidden group-hover:block duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
-											}
-											dark
-										/>
-										<TriangleIcon
-											className={
-												"ms-2 absolute group-hover:hidden duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
-											}
-										/>
-										Page 2/2
-									</button>
-								</div>
-							</div>
-						)}
-					</>
+					<div className="duration-300">
+						{faqGroup2.map((F) => (
+							<ListItemButton
+								key={F._key}
+								onClick={() => setFocusedQuestion(F)}
+								text={F.question}
+								inverted={false}
+								className="mb-0 py-[2px]"
+							/>
+						))}
+						<div className="flex justify-end ms-3 w-full">
+							<button
+								type="button"
+								onClick={() => {
+									setPage1Selected(true);
+								}}
+								className={
+									"w-[100px] xl:w-[105px] absolute flex items-center mt-4 group hover:bg-white hover:text-black px-[3px] xl:mt-4 duration-300"
+								}
+							>
+								<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
+								<TriangleIcon
+									className={
+										"ms-2 absolute hidden group-hover:block duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+									}
+									dark
+								/>
+								<TriangleIcon
+									className={
+										"ms-2 absolute group-hover:hidden duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+									}
+								/>
+								Page 2/2
+							</button>
+						</div>
+					</div>
 				)}
 			</div>
 		</div>

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
@@ -18,14 +18,14 @@ const FAQAccordionDesktop: React.FC<FAQAccordion> = ({ faq }) => {
 	const [focusedQuestion, setFocusedQuestion] = useState<null | FAQ>(null);
 
 	return (
-		<div className="flex flex-1 justify-center lg:h-auto mt-16 lg:mt-8 mb-[-250px] lg:mb-0">
+		<div className="hidden lg:flex flex-1 justify-center lg:h-auto mt-16 lg:mt-8 mb-[-250px] lg:mb-0">
 			{/* Desktop View */}
 			<Image
 				src={SpeechDesktop}
 				alt="Dialogue box background"
-				className="hidden lg:block h-fit lg:max-w-[630px] lg:h-[310px] xl:max-w-[775px] xl:h-[350px]"
+				className="lg:block h-fit lg:max-w-[630px] lg:h-[310px] xl:max-w-[775px] xl:h-[350px]"
 			/>
-			<div className="hidden lg:block absolute lg:w-[555px] xl:w-[685px] lg:text-[.85rem] xl:text-[1rem] mt-3">
+			<div className="lg:block absolute lg:w-[555px] xl:w-[685px] lg:text-[.85rem] xl:text-[1rem] mt-3">
 				{/* Page 1 focused */}
 				<div
 					className={`absolute w-full ${

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionDesktop.tsx
@@ -18,118 +18,116 @@ const FAQAccordionDesktop: React.FC<FAQAccordion> = ({ faq }) => {
 	const [focusedQuestion, setFocusedQuestion] = useState<null | FAQ>(null);
 
 	return (
-		<div className="hidden lg:flex flex-1 justify-center lg:h-auto mt-16 lg:mt-8 mb-[-250px] lg:mb-0">
-			{/* Desktop View */}
+		<div className="hidden lg:flex flex-1 justify-center lg:h-auto mt-16 lg:mt-8 mb-[-250px] lg:mb-0 lg:block">
 			<Image
 				src={SpeechDesktop}
 				alt="Dialogue box background"
-				className="lg:block h-fit lg:max-w-[630px] lg:h-[310px] xl:max-w-[775px] xl:h-[350px]"
+				className="duration-300 h-fit lg:max-w-[630px] lg:h-[310px] xl:max-w-[775px] xl:h-[350px]"
 			/>
-			<div className="lg:block absolute lg:w-[555px] xl:w-[685px] lg:text-[.85rem] xl:text-[1rem] mt-3">
-				{/* Page 1 focused */}
-				<div
-					className={`absolute w-full ${
-						page1Selected && !focusedQuestion
-							? "z-50"
-							: "hidden pointer-events-none"
-					}`}
-				>
-					{faqGroup1.map((F) => (
-						<ListItemButton
-							key={F._key}
-							onClick={() => setFocusedQuestion(F)}
-							text={F.question}
-							inverted={false}
-							className="mb-0 py-[2px]"
-						/>
-					))}
-					<div className="flex justify-end w-full ms-3">
-						<button
-							type="button"
-							onClick={() => {
-								setPage1Selected(false);
-							}}
-							className={`flex items-center opacity-100 hover:bg-white hover:text-black p-[1px] px-[3px] duration-200 group`}
-						>
-							Page 1/2
-							<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
-							<TriangleIcon
-								className={`ms-2 absolute hidden group-hover:block duration-200 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5`}
-								dark
+			<div className="absolute lg:w-[555px] xl:w-[685px] lg:text-[.85rem] xl:text-[1rem] mt-3">
+				{focusedQuestion ? (
+					<div className={"duration-300 absolute lg:h-[250px] xl:h-[285px]"}>
+						<div>
+							<ListItemButton
+								onClick={() => setFocusedQuestion(null)}
+								className="mb-2 py-[2px]"
+								text={focusedQuestion?.question}
+								rotate="rotate-90"
+								inverted
 							/>
-							<TriangleIcon
-								className={`ms-2 absolute group-hover:hidden duration-200 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5`}
+
+							<p className="ms-2">{focusedQuestion?.answer}</p>
+						</div>
+
+						<div className="absolute bottom-0">
+							<ListItemButton
+								onClick={() => setFocusedQuestion(null)}
+								className="py-[2px] min-w-[175px] xl:min-w-[200px]"
+								text="Ask another question"
+								rotate="rotate-180"
+								inverted={false}
 							/>
-						</button>
+						</div>
 					</div>
-				</div>
-
-				{/* Page 2 focused */}
-				<div
-					className={`absolute ${
-						!page1Selected && !focusedQuestion
-							? "z-50"
-							: "hidden pointer-events-none"
-					}`}
-				>
-					{faqGroup2.map((F) => (
-						<ListItemButton
-							key={F._key}
-							onClick={() => setFocusedQuestion(F)}
-							text={F.question}
-							inverted={false}
-							className="mb-0 py-[2px]"
-						/>
-					))}
-					<div className="flex justify-end ms-3 w-full">
-						<button
-							type="button"
-							onClick={() => {
-								setPage1Selected(true);
-							}}
-							className={`absolute flex items-center mt-4 group hover:bg-white hover:text-black p-[1px] px-[3px] xl:mt-4 duration-200 `}
-						>
-							<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
-							<TriangleIcon
-								className={`ms-2 absolute hidden group-hover:block duration-200 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5`}
-								dark
-							/>
-							<TriangleIcon
-								className={`ms-2 absolute group-hover:hidden duration-200 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5`}
-							/>
-							Page 2/2
-						</button>
-					</div>
-				</div>
-
-				{/* Question is focused. */}
-				<div
-					className={`${
-						focusedQuestion ? "z-50" : "hidden pointer-events-none"
-					} absolute lg:h-[250px] xl:h-[285px]`}
-				>
-					<div>
-						<ListItemButton
-							onClick={() => setFocusedQuestion(null)}
-							className="mb-2 py-[2px]"
-							text={focusedQuestion?.question}
-							rotate="rotate-90"
-							inverted
-						/>
-
-						<p className="ms-2">{focusedQuestion?.answer}</p>
-					</div>
-
-					<div className="absolute bottom-0">
-						<ListItemButton
-							onClick={() => setFocusedQuestion(null)}
-							className="py-[2px] min-w-[175px] xl:min-w-[200px]"
-							text="Ask another question"
-							rotate="rotate-180"
-							inverted={false}
-						/>
-					</div>
-				</div>
+				) : (
+					<>
+						{page1Selected ? (
+							<div className="duration-300">
+								{faqGroup1.map((F) => (
+									<ListItemButton
+										key={F._key}
+										onClick={() => setFocusedQuestion(F)}
+										text={F.question}
+										inverted={false}
+										className="mb-0 py-[2px]"
+									/>
+								))}
+								<div className="flex justify-end w-full ms-3">
+									<button
+										type="button"
+										onClick={() => {
+											setPage1Selected(false);
+										}}
+										className={
+											"flex items-center opacity-100 hover:bg-white hover:text-black px-[3px] duration-300 group"
+										}
+									>
+										Page 1/2
+										<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
+										<TriangleIcon
+											className={
+												"ms-2 absolute hidden group-hover:block duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+											}
+											dark
+										/>
+										<TriangleIcon
+											className={
+												"ms-2 absolute group-hover:hidden duration-300 right-[-7px] lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+											}
+										/>
+									</button>
+								</div>
+							</div>
+						) : (
+							<div className="duration-300">
+								{faqGroup2.map((F) => (
+									<ListItemButton
+										key={F._key}
+										onClick={() => setFocusedQuestion(F)}
+										text={F.question}
+										inverted={false}
+										className="mb-0 py-[2px]"
+									/>
+								))}
+								<div className="flex justify-end ms-3 w-full">
+									<button
+										type="button"
+										onClick={() => {
+											setPage1Selected(true);
+										}}
+										className={
+											"w-[100px] absolute flex items-center mt-4 group hover:bg-white hover:text-black px-[3px] xl:mt-4 duration-300"
+										}
+									>
+										<TriangleIcon className="ms-2 opacity-0 lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
+										<TriangleIcon
+											className={
+												"ms-2 absolute hidden group-hover:block duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+											}
+											dark
+										/>
+										<TriangleIcon
+											className={
+												"ms-2 absolute group-hover:hidden duration-300 left-[-5px] rotate-180 lg:w-4 lg:h-4 xl:w-5 xl:h-5"
+											}
+										/>
+										Page 2/2
+									</button>
+								</div>
+							</div>
+						)}
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
@@ -13,64 +13,63 @@ const FAQAccordionMobile: React.FC<FAQAccordion> = ({ faq }) => {
 
 	return (
 		<div
-			className={`w-[100%] relative flex flex-1 justify-center sm:text-lg md:text-xl lg:hidden ${
-				focusedQuestion ? "h-[480px]" : "h-[965px] sm:h-[940px] md:h-[1030px]"
+			className={`relative flex flex-1 justify-center sm:text-lg md:text-xl lg:hidden ${
+				focusedQuestion ? "h-[480px]" : "h-[965px] sm:h-[940px] md:h-[810px]"
 			}`}
 		>
 			<Image
 				src={SpeechMobile}
 				alt="Dialogue box background"
-				className={`${
+				className={`duration-300 ${
 					focusedQuestion
 						? "w-[95%] h-[480px] sm:h-[375px] sm:max-h-[620px]"
-						: ""
+						: "w-[300px] sm:w-[480px] md:w-[600px] h-[920px] sm:h-[745px] md:h-[800px]"
 				}`}
 			/>
-
-			{/* No question is focused. */}
-			<div
-				className={`${
-					focusedQuestion ? "hidden pointer-events-none" : "z-50"
-				} duration-200 w-[325px] sm:w-[450px] md:w-[560px] absolute mx-4 mt-2 h-fit`}
-			>
-				<div>
-					{faq.map((F) => (
-						<ListItemButton
-							key={F._key}
-							onClick={() => setFocusedQuestion(F)}
-							text={F.question}
-							className="md:p-2"
-							inverted={false}
-						/>
-					))}
-				</div>
-			</div>
-
-			{/* Question is focused. */}
-			<div
-				className={`${
-					focusedQuestion ? "z-50" : "hidden pointer-events-none"
-				} duration-200 absolute top-[35px] w-[85%] sm:w-[88%] h-[420px] sm:h-[325px]`}
-			>
-				<ListItemButton
-					onClick={() => setFocusedQuestion(null)}
-					className="mb-3"
-					text={focusedQuestion?.question}
-					rotate="rotate-90"
-					inverted
-				/>
-
-				<p>{focusedQuestion?.answer}</p>
-
-				<div className="-bottom-2 sm:bottom-0 absolute">
+			{focusedQuestion ? (
+				<div
+					className={
+						"duration-300 absolute top-[35px] w-[85%] sm:w-[88%] h-[420px] sm:h-[325px]"
+					}
+				>
 					<ListItemButton
 						onClick={() => setFocusedQuestion(null)}
-						text="Ask another question"
-						rotate="rotate-180"
-						inverted={false}
+						className="mb-3"
+						text={focusedQuestion?.question}
+						rotate="rotate-90"
+						inverted
 					/>
+
+					<p>{focusedQuestion?.answer}</p>
+
+					<div className="-bottom-2 sm:bottom-0 absolute">
+						<ListItemButton
+							onClick={() => setFocusedQuestion(null)}
+							text="Ask another question"
+							rotate="rotate-180"
+							inverted={false}
+						/>
+					</div>
 				</div>
-			</div>
+			) : (
+				<div
+					className={
+						"duration-300 w-[250px] sm:w-[450px] md:w-[560px] absolute top-14 sm:top-12 mx-4 h-fit"
+					}
+				>
+					<div>
+						{faq.map((F) => (
+							<ListItemButton
+								key={F._key}
+								onClick={() => setFocusedQuestion(F)}
+								text={F.question}
+								className="md:p-2"
+								inverted={false}
+							/>
+						))}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
@@ -12,68 +12,63 @@ const FAQAccordionMobile: React.FC<FAQAccordion> = ({ faq }) => {
 	const [focusedQuestion, setFocusedQuestion] = useState<null | FAQ>(null);
 
 	return (
-		<div className="flex flex-1 justify-center lg:h-auto mt-60 lg:mt-8 mb-[-250px] lg:mb-0 sm:text-lg md:text-xl">
-			{/* Changes size of parent component */}
-			<div
-				className={`z-0 ${
-					focusedQuestion ? "h-[520px]" : "h-[965px] sm:h-[940px] md:h-[1030px]"
-				} duration-200 transition-transform lg:hidden`}
+		<div
+			className={`w-[100%] relative flex flex-1 justify-center sm:text-lg md:text-xl lg:hidden ${
+				focusedQuestion ? "h-[480px]" : "h-[965px] sm:h-[940px] md:h-[1030px]"
+			}`}
+		>
+			<Image
+				src={SpeechMobile}
+				alt="Dialogue box background"
+				className={`${
+					focusedQuestion
+						? "w-[95%] h-[480px] sm:h-[375px] sm:max-h-[620px]"
+						: ""
+				}`}
 			/>
-			<div className="relative flex justify-center lg:hidden">
-				<Image
-					src={SpeechMobile}
-					alt="Dialogue box background"
-					className={`${
-						focusedQuestion
-							? "mt-[-160px] sm:mt-[-120px] sm:max-h-[620px]"
-							: "mt-[-275px] md:mt-[-300px]"
-					} min-w-[450px] sm:min-w-[600px] md:min-w-[750px] object-fill`}
-					layout="responsive"
-				/>
 
-				{/* No question is focused. */}
-				<div
-					className={`${
-						focusedQuestion ? "hidden pointer-events-none" : "z-50"
-					} duration-200 w-[325px] sm:w-[450px] md:w-[560px] absolute mx-4 mt-2 h-fit`}
-				>
-					<div>
-						{faq.map((F) => (
-							<ListItemButton
-								key={F._key}
-								onClick={() => setFocusedQuestion(F)}
-								text={F.question}
-								className="md:p-2"
-								inverted={false}
-							/>
-						))}
-					</div>
-				</div>
-
-				{/* Question is focused. */}
-				<div
-					className={`${
-						focusedQuestion ? "z-50" : "hidden pointer-events-none"
-					} duration-200 absolute w-[325px] sm:w-[450px] md:w-[570px] h-[350px] sm:h-[325px] mt-2 sm:mt-8`}
-				>
-					<ListItemButton
-						onClick={() => setFocusedQuestion(null)}
-						className="mb-3"
-						text={focusedQuestion?.question}
-						rotate="rotate-90"
-						inverted
-					/>
-
-					<p>{focusedQuestion?.answer}</p>
-
-					<div className="-bottom-2 absolute">
+			{/* No question is focused. */}
+			<div
+				className={`${
+					focusedQuestion ? "hidden pointer-events-none" : "z-50"
+				} duration-200 w-[325px] sm:w-[450px] md:w-[560px] absolute mx-4 mt-2 h-fit`}
+			>
+				<div>
+					{faq.map((F) => (
 						<ListItemButton
-							onClick={() => setFocusedQuestion(null)}
-							text="Ask another question"
-							rotate="rotate-180"
+							key={F._key}
+							onClick={() => setFocusedQuestion(F)}
+							text={F.question}
+							className="md:p-2"
 							inverted={false}
 						/>
-					</div>
+					))}
+				</div>
+			</div>
+
+			{/* Question is focused. */}
+			<div
+				className={`${
+					focusedQuestion ? "z-50" : "hidden pointer-events-none"
+				} duration-200 absolute top-[35px] w-[85%] sm:w-[88%] h-[420px] sm:h-[325px]`}
+			>
+				<ListItemButton
+					onClick={() => setFocusedQuestion(null)}
+					className="mb-3"
+					text={focusedQuestion?.question}
+					rotate="rotate-90"
+					inverted
+				/>
+
+				<p>{focusedQuestion?.answer}</p>
+
+				<div className="-bottom-2 sm:bottom-0 absolute">
+					<ListItemButton
+						onClick={() => setFocusedQuestion(null)}
+						text="Ask another question"
+						rotate="rotate-180"
+						inverted={false}
+					/>
 				</div>
 			</div>
 		</div>

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/FAQAccordionMobile.tsx
@@ -40,7 +40,7 @@ const FAQAccordionMobile: React.FC<FAQAccordion> = ({ faq }) => {
 						inverted
 					/>
 
-					<p>{focusedQuestion?.answer}</p>
+					{focusedQuestion?.answer}
 
 					<div className="-bottom-2 sm:bottom-0 absolute">
 						<ListItemButton

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/assets/speech-mobile.svg
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/assets/speech-mobile.svg
@@ -1,10 +1,3 @@
-<svg id="svg2" viewBox="0 0 500 670" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-  <desc>Source: openclipart.org/detail/209545</desc>
-  <defs>
-    <radialGradient id="radialGradient50" gradientUnits="userSpaceOnUse" cy="13.127" cx="23.404" gradientTransform="matrix(9.477364, 10.273408, 9.367074, -10.407683, -215.77565, 326.421863)" r="14.286">
-      <stop id="stop52" style="stop-color: #ff0008" offset="0"></stop>
-      <stop id="stop54" style="stop-color: #800005" offset="1"></stop>
-    </radialGradient>
-  </defs>
-  <path d="M 261.585 142.94 L 456.424 142.94 L 456.424 537.561 L 57.578 537.561 L 45.101 537.561 L 45.101 474.35 L 45.101 142.94 L 236.459 142.94 L 237.456 142.94 L 238.064 142.108 L 248.77 127.503 L 260.006 142.146 L 260.617 142.94 L 261.585 142.94 Z" fill="#0C071B" stroke="white" stroke-width="3" style=""></path>
+<svg viewBox="0 0 307 291" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
+<path d="M161.498 13.2246H305.5V289.5H10.7206H1.5L1.5 245.246V13.2246H142.929H143.665L144.115 12.6425L152.027 2.41636L160.332 12.6688L160.783 13.2246H161.498Z" fill="#0C071B" stroke="white" stroke-width="3"/>
 </svg>

--- a/apps/site/src/app/(main)/(home)/sections/FAQ/components/ListItemButton.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/FAQ/components/ListItemButton.tsx
@@ -17,7 +17,7 @@ export default function ListItemButton({
 		<button
 			type="button"
 			onClick={onClick}
-			className={`flex items-center gap-3 duration-200 p-[5px] lg:p-[4px] xl:p-[4px] group ${
+			className={`flex items-center gap-3 duration-300 p-[5px] lg:p-[4px] xl:p-[4px] group ${
 				inverted ? "bg-white" : "hover:bg-white"
 			} ${className}`}
 		>

--- a/apps/site/src/app/(main)/(home)/sections/Partners/Partners.tsx
+++ b/apps/site/src/app/(main)/(home)/sections/Partners/Partners.tsx
@@ -66,7 +66,7 @@ export default async function Partners() {
 						<img
 							src={builder.image(logo).format("webp").url()}
 							alt={`${name} logo`}
-							className="max-w-full max-h-full object-contain"
+							className="h-full max-w-full max-h-full object-contain"
 						/>
 					</a>
 				))}

--- a/apps/site/src/lib/components/forms/MultipleSelect.tsx
+++ b/apps/site/src/lib/components/forms/MultipleSelect.tsx
@@ -69,7 +69,7 @@ export default function MultipleSelect({
 					const inputId = `${name}-${i}`;
 					if (item.value === "other") {
 						return (
-							<div key={item.value} className="flex gap-2">
+							<div key={item.value} className="flex gap-2 items-center">
 								<input
 									id={inputId}
 									type={inputType}
@@ -90,7 +90,7 @@ export default function MultipleSelect({
 						);
 					}
 					return (
-						<div key={i} className="flex gap-2">
+						<div key={i} className="flex gap-2 items-center">
 							<input
 								id={inputId}
 								type={inputType}

--- a/apps/site/src/lib/components/forms/Slider.tsx
+++ b/apps/site/src/lib/components/forms/Slider.tsx
@@ -41,7 +41,7 @@ export default function Slider({
 					<SliderTick leftPercentage="74%" label="4" />
 					<SliderTick leftPercentage="98.7%" label="5" />
 					<input
-						className="w-full h-2 bg-white appearance-none rounded-full z-10"
+						className="w-full h-1 bg-white appearance-none rounded-full z-10"
 						type="range"
 						min="1"
 						max="5"

--- a/apps/site/src/lib/components/forms/shared/ApplyConfirmation/ApplyConfirm.tsx
+++ b/apps/site/src/lib/components/forms/shared/ApplyConfirmation/ApplyConfirm.tsx
@@ -32,7 +32,7 @@ export default async function ApplyConfirm({
 			  : ""; // eslint-disable-line
 
 	return (
-		<div className="flex items-center py-16">
+		<div className="flex items-center pt-24 pb-16">
 			<ConfirmationDetails
 				isLoggedIn={identity.uid !== null}
 				applicationURL={applicationURL}

--- a/apps/site/src/lib/components/forms/shared/Title/Title.tsx
+++ b/apps/site/src/lib/components/forms/shared/Title/Title.tsx
@@ -3,10 +3,12 @@ interface TitleProps {
 }
 
 export default function Title({ applicationType }: TitleProps) {
+	const applyTitle = `Apply as a ${applicationType}`;
+
 	return (
 		<>
 			<h1 className="text-[var(--color-white)] text-center font-display font-bold text-3xl md:text-5xl">
-				Apply as a {applicationType}
+				{applyTitle}
 			</h1>
 			<h2 className="text-[var(--color-offwhite)] text-center font-body text-xl my-6 sm:text-2xl md:text-4xl">
 				Applications close on January 10th, 11:59PM PST


### PR DESCRIPTION
## Changes
UI changes for Safari
- Refactors to use conditional rendering as opposed to `hidden` and fixes FAQs (`transition-duration` now working as initially wanted in #428 )
- Fixes application UI such as
  - "Apply as a Hacker" title
  - alignment of pronouns multi-select checkboxes with their labels
  - `git_experience` slider more visible
  - ensure all blocks in `Partners` have the same height
- Also, fixes `p cannot be a descendant of p` error encountered on FAQs

Handing this off to @noahk004 

Closes #507 