### PR TITLE
fix: remove applied before question from volunteer applications

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -97,7 +97,6 @@ class BaseVolunteerApplicationData(BaseModel):
     school: str
     education_level: str
     major: str
-    applied_before: bool
     frq_volunteer: str = Field(max_length=2048)
     frq_utensil: str = Field(max_length=2048)
     allergies: Union[str, None] = Field(None, max_length=2048)

--- a/apps/api/tests/test_user_volunteer_apply.py
+++ b/apps/api/tests/test_user_volunteer_apply.py
@@ -170,7 +170,7 @@ def test_volunteer_apply_with_confirmation_email_issue_causes_500(
 def test_volunteer_application_data_is_bson_encodable() -> None:
     """Test that application data model can be encoded into BSON to store in MongoDB."""
     encoded = bson.encode(EXPECTED_APPLICATION_DATA.model_dump())
-    assert len(encoded) == 437
+    assert len(encoded) == 420
 
 
 def test_volunteer_past_deadline_causes_403() -> None:

--- a/apps/api/tests/test_user_volunteer_apply.py
+++ b/apps/api/tests/test_user_volunteer_apply.py
@@ -31,7 +31,6 @@ SAMPLE_APPLICATION = {
     "school": "UC Irvine",
     "education_level": "Fifth+ Year Undergraduate",
     "major": "Computer Science",
-    "applied_before": "false",
     "frq_volunteer": "",
     "frq_utensil": "",
     "other_questions": "",

--- a/apps/site/src/app/(main)/volunteer/components/VolunteerFRQ.tsx
+++ b/apps/site/src/app/(main)/volunteer/components/VolunteerFRQ.tsx
@@ -1,22 +1,9 @@
-import MultipleSelect from "@/lib/components/forms/MultipleSelect";
 import Textfield from "@/lib/components/forms/Textfield";
 
 export default function VolunteerFRQ() {
 	return (
 		<div className="flex flex-col items-start w-11/12 gap-5">
 			<div className="text-4xl font-bold">Volunteer Information</div>
-			<MultipleSelect
-				name="applied_before"
-				labelText="Did you apply to be a hacker for IrvineHacks 2025?"
-				values={[
-					{ value: "Yes", text: "Yes" },
-					{ value: "No", text: "No" },
-				]}
-				containerClass=""
-				inputType="radio"
-				horizontal={true}
-				isRequired={true}
-			/>
 			<Textfield
 				name="frq_volunteer"
 				labelText="Why are you interested in volunteering, and what do you expect to gain from this experience?"

--- a/apps/site/src/app/admin/applicants/volunteers/components/VolunteerApplication.tsx
+++ b/apps/site/src/app/admin/applicants/volunteers/components/VolunteerApplication.tsx
@@ -13,7 +13,7 @@ interface VolunteerApplicationSections {
 
 const VOLUNTEER_APPLICATION_SECTIONS: VolunteerApplicationSections = {
 	"Personal Information": ["pronouns", "ethnicity", "is_18_older"],
-	Education: ["school", "education_level", "major", "applied_before"],
+	Education: ["school", "education_level", "major"],
 	"Free Response Questions": [
 		"frq_volunteer",
 		"frq_utensil",

--- a/apps/site/src/lib/admin/useApplicant.ts
+++ b/apps/site/src/lib/admin/useApplicant.ts
@@ -44,7 +44,6 @@ export interface MentorApplicationData extends BaseApplicationData {
 }
 
 export interface VolunteerApplicationData extends BaseApplicationData {
-	applied_before: boolean;
 	frq_volunteer: string;
 	frq_utensil: string;
 	allergies: string | null;


### PR DESCRIPTION
Summary
- Removes everything on the frontend and backend related to the "applied_before" question for the volunteer application

Test Plan
- Create a user, submit a volunteer app, ensure data is transferred and saved properly

Closes #541 