### PR TITLE
Add logistics email sender

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -398,7 +398,6 @@ async def retrieve_thresholds() -> Optional[dict[str, Any]]:
     )
 
 
-
 async def _try_update_applicant_with_query(
     applicant_review: ReviewRequest,
     *,

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -329,7 +329,7 @@ async def waitlist_release(
 
     log.info("%s accepted %s off the waitlist. Sending email.", associate, uid)
     await email_handler.send_waitlist_release_email(
-        record["first_name"], recover_email_from_uid(uid)
+        record["first_name"], email_handler.recover_email_from_uid(uid)
     )
 
 
@@ -397,14 +397,6 @@ async def retrieve_thresholds() -> Optional[dict[str, Any]]:
         Collection.SETTINGS, {"_id": "hacker_score_thresholds"}, ["accept", "waitlist"]
     )
 
-
-def recover_email_from_uid(uid: str) -> str:
-    """For NativeUsers, the email should still delivery properly."""
-    uid = uid.replace("..", "\n")
-    *reversed_domain, local = uid.split(".")
-    local = local.replace("\n", ".")
-    domain = ".".join(reversed(reversed_domain))
-    return f"{local}@{domain}"
 
 
 async def _try_update_applicant_with_query(

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -422,12 +422,28 @@ async def release_hacker_decisions() -> None:
     await _process_records_in_batches(records, Role.HACKER)
 
 
-@router.post("/logistics", dependencies=[Depends(require_director)])
-async def release_logistics_emails() -> None:
-    """Send logistics email."""
+@router.post("/logistics/hackers", dependencies=[Depends(require_director)])
+async def hacker_logistics_emails() -> None:
+    """Send logistics emails to hackers."""
     await email_handler.send_logistics_email(Role.HACKER)
+
+
+@router.post("/logistics/mentors", dependencies=[Depends(require_director)])
+async def mentor_logistics_emails() -> None:
+    """Send logistics email to mentors."""
     await email_handler.send_logistics_email(Role.MENTOR)
+
+
+@router.post("/logistics/volunteers", dependencies=[Depends(require_director)])
+async def volunteer_logistics_emails() -> None:
+    """Send logistics email to volunteers."""
     await email_handler.send_logistics_email(Role.VOLUNTEER)
+
+
+@router.post("/logistics/waitlists", dependencies=[Depends(require_director)])
+async def waitlist_logistics_emails() -> None:
+    """Send logistics email to waitlisted hackers."""
+    await email_handler.send_logistics_email(Decision.WAITLISTED)
 
 
 async def _process_status(uids: Sequence[str], status: Status) -> None:

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -422,6 +422,14 @@ async def release_hacker_decisions() -> None:
     await _process_records_in_batches(records, Role.HACKER)
 
 
+@router.post("/logistics", dependencies=[Depends(require_director)])
+async def release_logistics_emails() -> None:
+    """Send logistics email."""
+    await email_handler.send_logistics_email(Role.HACKER)
+    await email_handler.send_logistics_email(Role.MENTOR)
+    await email_handler.send_logistics_email(Role.VOLUNTEER)
+
+
 async def _process_status(uids: Sequence[str], status: Status) -> None:
     ok = await mongodb_handler.update(
         Collection.USERS, {"_id": {"$in": uids}}, {"status": status}
@@ -472,13 +480,3 @@ def _extract_personalizations(decision_data: dict[str, Any]) -> tuple[str, Email
     name = decision_data["first_name"]
     email = recover_email_from_uid(decision_data["_id"])
     return name, email
-
-
-class RoleRequest(BaseModel):
-    role: Literal[Role.HACKER, Role.MENTOR, Role.VOLUNTEER]
-
-
-@router.post("/logistics", dependencies=[Depends(require_director)])
-async def release_logistics_emails(request: RoleRequest) -> None:
-    """Send logistics email."""
-    await email_handler.send_logistics_email(request.role)

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -21,7 +21,7 @@ from services.sendgrid_handler import (
 )
 from routers.admin import retrieve_thresholds
 from utils import email_handler
-from utils.email_handler import IH_SENDER
+from utils.email_handler import IH_SENDER, recover_email_from_uid
 from utils.batched import batched
 
 log = getLogger(__name__)
@@ -476,8 +476,9 @@ def _extract_personalizations(decision_data: dict[str, Any]) -> tuple[str, Email
 
 class RoleRequest(BaseModel):
     role: Literal[Role.HACKER, Role.MENTOR, Role.VOLUNTEER]
-    
+
+
 @router.post("/logistics", dependencies=[Depends(require_director)])
-async def release_hacker_decisions(request: RoleRequest) -> None:
+async def release_logistics_emails(request: RoleRequest) -> None:
     """Send logistics email."""
     await email_handler.send_logistics_email(request.role)

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -19,7 +19,7 @@ from services.sendgrid_handler import (
     PersonalizationData,
     Template,
 )
-from routers.admin import recover_email_from_uid, retrieve_thresholds
+from routers.admin import retrieve_thresholds
 from utils import email_handler
 from utils.email_handler import IH_SENDER
 from utils.batched import batched
@@ -472,3 +472,12 @@ def _extract_personalizations(decision_data: dict[str, Any]) -> tuple[str, Email
     name = decision_data["first_name"]
     email = recover_email_from_uid(decision_data["_id"])
     return name, email
+
+
+class RoleRequest(BaseModel):
+    role: Literal[Role.HACKER, Role.MENTOR, Role.VOLUNTEER]
+    
+@router.post("/logistics", dependencies=[Depends(require_director)])
+async def release_hacker_decisions(request: RoleRequest) -> None:
+    """Send logistics email."""
+    await email_handler.send_logistics_email(request.role)

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -458,9 +458,10 @@ async def waitlist_logistics_emails() -> None:
             )
         )
 
-    await sendgrid_handler.send_email(
-        Template.HACKER_WAITLISTED_LOGISTICS_EMAIL, IH_SENDER, personalizations, True
-    )
+    if len(records) > 0:
+        await sendgrid_handler.send_email(
+            Template.HACKER_WAITLISTED_LOGISTICS_EMAIL, IH_SENDER, personalizations, True
+        )
 
 
 async def _process_status(uids: Sequence[str], status: Status) -> None:

--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -460,7 +460,10 @@ async def waitlist_logistics_emails() -> None:
 
     if len(records) > 0:
         await sendgrid_handler.send_email(
-            Template.HACKER_WAITLISTED_LOGISTICS_EMAIL, IH_SENDER, personalizations, True
+            Template.HACKER_WAITLISTED_LOGISTICS_EMAIL,
+            IH_SENDER,
+            personalizations,
+            True,
         )
 
 

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -53,7 +53,6 @@ class ApplicationUpdatePersonalization(PersonalizationData):
     first_name: str
 
 
-
 ApplicationUpdateTemplates: TypeAlias = Literal[
     Template.HACKER_ACCEPTED_EMAIL,
     Template.HACKER_WAITLISTED_EMAIL,

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -74,6 +74,7 @@ LogisticsTemplates: TypeAlias = Literal[
 ]
 
 
+
 @overload
 async def send_email(
     template_id: Literal[Template.CONFIRMATION_EMAIL],

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -74,7 +74,6 @@ LogisticsTemplates: TypeAlias = Literal[
 ]
 
 
-
 @overload
 async def send_email(
     template_id: Literal[Template.CONFIRMATION_EMAIL],

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -33,6 +33,7 @@ class Template(str, Enum):
     HACKER_LOGISTICS_EMAIL = "d-daa64b617d914a5996d51003e6d900a6"
     MENTOR_LOGISTICS_EMAIL = "d-2fb645c51c1a450babe5434162884ee4"
     VOLUNTEER_LOGISTICS_EMAIL = "d-c1cb63658bfe412aa9c8b327cceb29a7"
+    HACKER_WAITLISTED_LOGISTICS_EMAIL = "d-96dee09b12ef49b3977353fb96ee866e"
 
 
 class PersonalizationData(TypedDict):
@@ -71,6 +72,7 @@ LogisticsTemplates: TypeAlias = Literal[
     Template.HACKER_LOGISTICS_EMAIL,
     Template.MENTOR_LOGISTICS_EMAIL,
     Template.VOLUNTEER_LOGISTICS_EMAIL,
+    Template.HACKER_WAITLISTED_LOGISTICS_EMAIL,
 ]
 
 

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -143,6 +143,16 @@ async def send_email(
 ) -> None: ...
 
 
+@overload
+async def send_email(
+    template_id: Literal[Template.HACKER_LOGISTICS_EMAIL, Template.MENTOR_LOGISTICS_EMAIL, Template.VOLUNTEER_LOGISTICS_EMAIL],
+    sender_email: Tuple[str, str],
+    receiver_data: Iterable[PersonalizationData],
+    send_to_multiple: Literal[True],
+    reply_to: Union[Tuple[str, str], None] = None,
+) -> None: ...
+
+
 async def send_email(
     template_id: Template,
     sender_email: Tuple[str, str],

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -30,6 +30,9 @@ class Template(str, Enum):
     MENTOR_RSVP_REMINDER = "d-44da492ad79945a8932904904c39141b"
     VOLUNTEER_RSVP_REMINDER = "d-10a22149e4594cdf85d861f9e420dbe8"
     WAITLIST_RELEASE_EMAIL = "d-467b8de41d214f33ad9b6cc98cbb6c05"
+    HACKER_LOGISTICS_EMAIL = "d-daa64b617d914a5996d51003e6d900a6"
+    MENTOR_LOGISTICS_EMAIL = "d-2fb645c51c1a450babe5434162884ee4"
+    VOLUNTEER_LOGISTICS_EMAIL = "d-c1cb63658bfe412aa9c8b327cceb29a7"
 
 
 class PersonalizationData(TypedDict):
@@ -50,6 +53,7 @@ class ApplicationUpdatePersonalization(PersonalizationData):
     first_name: str
 
 
+
 ApplicationUpdateTemplates: TypeAlias = Literal[
     Template.HACKER_ACCEPTED_EMAIL,
     Template.HACKER_WAITLISTED_EMAIL,
@@ -64,6 +68,11 @@ ApplicationUpdateTemplates: TypeAlias = Literal[
     Template.WAITLIST_RELEASE_EMAIL,
 ]
 
+LogisticsTemplates: TypeAlias = Literal[
+    Template.HACKER_LOGISTICS_EMAIL,
+    Template.MENTOR_LOGISTICS_EMAIL,
+    Template.VOLUNTEER_LOGISTICS_EMAIL,
+]
 
 @overload
 async def send_email(

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -146,13 +146,19 @@ async def send_email(
 
 @overload
 async def send_email(
-    template_id: Literal[
-        Template.HACKER_LOGISTICS_EMAIL,
-        Template.MENTOR_LOGISTICS_EMAIL,
-        Template.VOLUNTEER_LOGISTICS_EMAIL,
-    ],
+    template_id: LogisticsTemplates,
     sender_email: Tuple[str, str],
-    receiver_data: Iterable[PersonalizationData],
+    receiver_data: ApplicationUpdatePersonalization,
+    send_to_multiple: Literal[False],
+    reply_to: Union[Tuple[str, str], None] = None,
+) -> None: ...
+
+
+@overload
+async def send_email(
+    template_id: LogisticsTemplates,
+    sender_email: Tuple[str, str],
+    receiver_data: Iterable[ApplicationUpdatePersonalization],
     send_to_multiple: Literal[True],
     reply_to: Union[Tuple[str, str], None] = None,
 ) -> None: ...

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -145,7 +145,11 @@ async def send_email(
 
 @overload
 async def send_email(
-    template_id: Literal[Template.HACKER_LOGISTICS_EMAIL, Template.MENTOR_LOGISTICS_EMAIL, Template.VOLUNTEER_LOGISTICS_EMAIL],
+    template_id: Literal[
+        Template.HACKER_LOGISTICS_EMAIL,
+        Template.MENTOR_LOGISTICS_EMAIL,
+        Template.VOLUNTEER_LOGISTICS_EMAIL,
+    ],
     sender_email: Tuple[str, str],
     receiver_data: Iterable[PersonalizationData],
     send_to_multiple: Literal[True],

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -73,6 +73,7 @@ LogisticsTemplates: TypeAlias = Literal[
     Template.VOLUNTEER_LOGISTICS_EMAIL,
 ]
 
+
 @overload
 async def send_email(
     template_id: Literal[Template.CONFIRMATION_EMAIL],

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -103,7 +103,7 @@ async def send_waitlist_release_email(first_name: str, email: EmailStr) -> None:
 
 async def send_logistics_email(role: Role) -> None:
     """Send logistics email to a particular group."""
-    records: list[dict[str, Any]] = []
+    records = []
     records = await mongodb_handler.retrieve(
         mongodb_handler.Collection.USERS,
         {"roles": Role(role)},

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -30,11 +30,13 @@ DECISION_TEMPLATES: dict[Role, dict[Decision, ApplicationUpdateTemplates]] = {
     },
 }
 
+
 LOGISTICS_TEMPLATES: dict[Role, LogisticsTemplates] = {
     Role.HACKER: Template.HACKER_LOGISTICS_EMAIL,
     Role.MENTOR: Template.MENTOR_LOGISTICS_EMAIL,
     Role.VOLUNTEER: Template.VOLUNTEER_LOGISTICS_EMAIL,
 }
+
 
 class ContactInfo(Protocol):
     first_name: str
@@ -98,11 +100,10 @@ async def send_waitlist_release_email(first_name: str, email: EmailStr) -> None:
         send_to_multiple=False,
     )
 
+
 async def send_logistics_email(role: Role) -> None:
     """Send logistics email to a particular group."""
-    
     records: list[dict[str, Any]] = []
-
     records = await mongodb_handler.retrieve(
         mongodb_handler.Collection.USERS,
         {

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -106,9 +106,7 @@ async def send_logistics_email(role: Role) -> None:
     records: list[dict[str, Any]] = []
     records = await mongodb_handler.retrieve(
         mongodb_handler.Collection.USERS,
-        {
-            "roles": Role(role)
-        },
+        {"roles": Role(role)},
         ["_id", "first_name"],
     )
 

--- a/apps/api/src/utils/email_handler.py
+++ b/apps/api/src/utils/email_handler.py
@@ -121,8 +121,8 @@ async def send_logistics_email(
         )
 
     template = LOGISTICS_TEMPLATES[application_type]
-
-    await sendgrid_handler.send_email(template, IH_SENDER, personalizations, True)
+    if len(records) > 0:
+        await sendgrid_handler.send_email(template, IH_SENDER, personalizations, True)
 
 
 def recover_email_from_uid(uid: str) -> str:

--- a/apps/site/src/app/admin/directors/email-sender/EmailSender.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/EmailSender.tsx
@@ -13,6 +13,7 @@ import ApplyReminder from "./components/ApplyReminder";
 import ReleaseNonHackerDecisions from "./components/ReleaseDecisions";
 import ReleaseHackerDecisions from "./components/ReleaseHackerDecisions";
 import RSVPReminder from "./components/RSVPReminder";
+import Logistics from "./components/Logistics"
 
 function EmailSender() {
 	const router = useRouter();
@@ -30,6 +31,8 @@ function EmailSender() {
 			<ReleaseHackerDecisions />
 			<RSVPReminder />
 			<ApplyReminder />
+			<Header>Logistics Emails</Header>
+			<Logistics />
 		</SpaceBetween>
 	);
 }

--- a/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
@@ -1,38 +1,15 @@
-import Box from "@cloudscape-design/components/box";
-
-import useEmailSenders from "@/lib/admin/useEmailSenders";
-import Senders from "./Senders";
 import SendGroup from "./SendGroup";
 
 function Logistics() {
-	const { senders, mutate } = useEmailSenders();
-
-	const roles = ["Hacker", "Mentor", "Volunteer"];
-
 	return (
-		<>
-			{roles.map((role, key) => {
-				const body = {
-                    role
-                }
-                
-                return (
-					<div key={key}>
-						<SendGroup
-							description={`Send out logistics emails to role: ${role}`}
-							buttonText="Send Logistics Emails"
-							modalText={`You are about to send out reminder emails to role: ${role}.`}
-							route="/api/director/logistics"
-							body={body}
-							mutate={mutate}
-						/>
-
-						<Box variant="awsui-key-label">Emails Sent</Box>
-						<Senders senders={senders} />
-					</div>
-				);
-			})}
-		</>
+		<SendGroup
+			description={"Send out logistics emails"}
+			buttonText="Send Logistics Emails"
+			modalText={
+				"You are about to send out logistics emails to hackers, mentors, and volunteers."
+			}
+			route="/api/director/logistics"
+		/>
 	);
 }
 

--- a/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
@@ -1,15 +1,21 @@
+import { SpaceBetween } from "@cloudscape-design/components";
 import SendGroup from "./SendGroup";
 
 function Logistics() {
 	return (
-		<SendGroup
-			description={"Send out logistics emails"}
-			buttonText="Send Logistics Emails"
-			modalText={
-				"You are about to send out logistics emails to hackers, mentors, and volunteers."
-			}
-			route="/api/director/logistics"
-		/>
+		<SpaceBetween size="m">
+			{["hackers", "mentors", "volunteers", "waitlists"].map((type, key) => {
+				return (
+					<SendGroup
+						key={key}
+						description={`Send out logistics emails to ${type}`}
+						buttonText="Send Logistics Emails"
+						modalText={`You are about to send out logistics emails to ${type}!`}
+						route={`/api/director/logistics/${type}`}
+					/>
+				);
+			})}
+		</SpaceBetween>
 	);
 }
 

--- a/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/components/Logistics.tsx
@@ -1,0 +1,39 @@
+import Box from "@cloudscape-design/components/box";
+
+import useEmailSenders from "@/lib/admin/useEmailSenders";
+import Senders from "./Senders";
+import SendGroup from "./SendGroup";
+
+function Logistics() {
+	const { senders, mutate } = useEmailSenders();
+
+	const roles = ["Hacker", "Mentor", "Volunteer"];
+
+	return (
+		<>
+			{roles.map((role, key) => {
+				const body = {
+                    role
+                }
+                
+                return (
+					<div key={key}>
+						<SendGroup
+							description={`Send out logistics emails to role: ${role}`}
+							buttonText="Send Logistics Emails"
+							modalText={`You are about to send out reminder emails to role: ${role}.`}
+							route="/api/director/logistics"
+							body={body}
+							mutate={mutate}
+						/>
+
+						<Box variant="awsui-key-label">Emails Sent</Box>
+						<Senders senders={senders} />
+					</div>
+				);
+			})}
+		</>
+	);
+}
+
+export default Logistics;

--- a/apps/site/src/app/admin/directors/email-sender/components/SendGroup.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/components/SendGroup.tsx
@@ -19,6 +19,7 @@ interface SendGroupProps {
 	buttonText: string;
 	modalText: string;
 	route: string;
+	body?: unknown;
 	mutate?: KeyedMutator<Sender[]>;
 }
 
@@ -27,6 +28,7 @@ function SendGroup({
 	buttonText,
 	modalText,
 	route,
+	body,
 	mutate,
 }: SendGroupProps) {
 	const [visible, setVisible] = useState(false);
@@ -35,8 +37,9 @@ function SendGroup({
 	>([]);
 
 	const handleClick = async () => {
+
 		await axios
-			.post(route)
+			.post(route, body ? body : undefined)
 			.then(() => {
 				setFlashBarItems([
 					{

--- a/apps/site/src/app/admin/directors/email-sender/components/SendGroup.tsx
+++ b/apps/site/src/app/admin/directors/email-sender/components/SendGroup.tsx
@@ -19,7 +19,6 @@ interface SendGroupProps {
 	buttonText: string;
 	modalText: string;
 	route: string;
-	body?: unknown;
 	mutate?: KeyedMutator<Sender[]>;
 }
 
@@ -28,7 +27,6 @@ function SendGroup({
 	buttonText,
 	modalText,
 	route,
-	body,
 	mutate,
 }: SendGroupProps) {
 	const [visible, setVisible] = useState(false);
@@ -37,9 +35,8 @@ function SendGroup({
 	>([]);
 
 	const handleClick = async () => {
-
 		await axios
-			.post(route, body ? body : undefined)
+			.post(route)
 			.then(() => {
 				setFlashBarItems([
 					{


### PR DESCRIPTION
## Changes
- Adds new API routes called `/api/director/logistics/hackers`, `/api/director/logistics/mentors`, `/api/director/logistics/volunteers`, and `/api/director/logistics/waitlists` that will send out logistics emails to all hackers, mentors, and volunteers that have been accepted and RSVP'd, and also logistics emails to waitlisted hackers
  - This design choice was made to provide maximum flexibility for all committees in the case they want to send out their logistics/follow up emails at different times (e.g. IH 25 Volunteers and Mentors wants to send them at a later time than Event Info/Applications)
- Adds UI to `EmailSender` page
- Moves `recover_email_from_uid` to `email_handler.py`

## Testing

1. Grant yourself a director identity
2. Make sure you have users of varying statuses `WAITLISTED`, `VOID`, `ATTENDING`, and the other statuses. Create users if you don't have any
3. Verify that emails are only sent to the users with statuses of `ATTENDING` and `WAITLISTED`.