### PR TITLE
Transfer void hackers to waitlist

### DIFF
--- a/apps/api/src/routers/director.py
+++ b/apps/api/src/routers/director.py
@@ -496,7 +496,7 @@ async def waitlist_transfer() -> None:
             )
         )
 
-    log.info(f"Sending waitlist transfer emails to {len(records)} users")
+    log.info(f"Sending waitlist transfer emails to {len(records)} hackers")
 
     if len(records) > 0:
         await sendgrid_handler.send_email(

--- a/apps/api/src/services/sendgrid_handler.py
+++ b/apps/api/src/services/sendgrid_handler.py
@@ -34,6 +34,7 @@ class Template(str, Enum):
     MENTOR_LOGISTICS_EMAIL = "d-2fb645c51c1a450babe5434162884ee4"
     VOLUNTEER_LOGISTICS_EMAIL = "d-c1cb63658bfe412aa9c8b327cceb29a7"
     HACKER_WAITLISTED_LOGISTICS_EMAIL = "d-96dee09b12ef49b3977353fb96ee866e"
+    WAITLIST_TRANSFER_EMAIL = "d-d31a55e147e74d1689d859c88de19d9d"
 
 
 class PersonalizationData(TypedDict):
@@ -66,6 +67,7 @@ ApplicationUpdateTemplates: TypeAlias = Literal[
     Template.MENTOR_RSVP_REMINDER,
     Template.VOLUNTEER_RSVP_REMINDER,
     Template.WAITLIST_RELEASE_EMAIL,
+    Template.WAITLIST_TRANSFER_EMAIL,
 ]
 
 LogisticsTemplates: TypeAlias = Literal[

--- a/apps/site/src/app/admin/directors/Directors.tsx
+++ b/apps/site/src/app/admin/directors/Directors.tsx
@@ -26,6 +26,12 @@ function Directors() {
 				modalText="You are about to update all applicant statuses and this can't be reversed"
 				route="/api/director/confirm-attendance"
 			/>
+			<SendGroup
+				description="Waitlist all accepted hackers that failed to RSVP on time"
+				buttonText="Update hacker statuses (Waitlist Transfer)"
+				modalText="You are about to update all hacker statuses and this can't be reversed"
+				route="/api/director/waitlist-transfer"
+			/>
 		</>
 	);
 }


### PR DESCRIPTION
## Changes
- Adds new backend route `/api/director/waitlist-transfer` that will change the statuses of all hackers with status `VOID` to `WAITLISTED` and send out waitlist transfer emails
- Adds frontend that accesses this route at `/admin/directors`

## Testing
1. Give yourself a director identity
2. Create some hacker users that have statuses of `VOID`
3. Verify that after accessing the new backend route these hackers' statuses become `WAITLISTED`

Closes #584 