### PR TITLE
Check-in admin portal setup

### DIFF
--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -73,7 +73,7 @@ async def get_non_hackers() -> list[Participant]:
     return [Participant(**user) for user in records]
 
 
-async def check_in_participant(uid: str, badge_number: str, associate: User) -> None:
+async def check_in_participant(uid: str, associate: User) -> None:
     """Check in participant at IrvineHacks"""
     record: Optional[dict[str, object]] = await mongodb_handler.retrieve_one(
         Collection.USERS, {"_id": uid, "roles": {"$exists": True}}, ["status"]
@@ -92,13 +92,12 @@ async def check_in_participant(uid: str, badge_number: str, associate: User) -> 
         {"_id": uid},
         {
             "$push": {"checkins": new_checkin_entry},
-            "$set": {"badge_number": badge_number},
         },
     )
     if not update_status:
         raise RuntimeError(f"Could not update check-in record for {uid}.")
 
-    log.info(f"Applicant {uid} ({badge_number}) checked in by {associate.uid}")
+    log.info(f"Applicant {uid} checked in by {associate.uid}")
 
 
 async def confirm_attendance_non_hacker(uid: str, director: User) -> None:

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -345,12 +345,11 @@ async def participants() -> list[Participant]:
 @router.post("/checkin/{uid}")
 async def check_in_participant(
     uid: str,
-    badge_number: Annotated[str, Body()],
     associate: Annotated[User, Depends(require_organizer)],
 ) -> None:
     """Check in participant at IrvineHacks."""
     try:
-        await participant_manager.check_in_participant(uid, badge_number, associate)
+        await participant_manager.check_in_participant(uid, associate)
     except ValueError:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     except RuntimeError as err:

--- a/apps/site/src/app/admin/events/Events.tsx
+++ b/apps/site/src/app/admin/events/Events.tsx
@@ -6,28 +6,12 @@ import ContentLayout from "@cloudscape-design/components/content-layout";
 import Select, { SelectProps } from "@cloudscape-design/components/select";
 
 import useEvents from "@/lib/admin/useEvents";
-import useParticipants, { Participant } from "@/lib/admin/useParticipants";
-
-import SubeventCheckin from "./components/SubeventCheckin";
 
 function Events() {
 	const [event, setEvent] = useState<SelectProps.Option | null>(null);
 
-	const {
-		events,
-		loading: loadingEvents,
-		checkInParticipantSubevent,
-	} = useEvents();
-	const { participants, loading: loadingParticipants } = useParticipants();
-
+	const { events, loading: loadingEvents } = useEvents();
 	const options = events.map(({ name, _id }) => ({ label: name, value: _id }));
-
-	const onConfirm = async (participant: Participant): Promise<boolean> => {
-		if (event !== null && event.value !== undefined) {
-			return await checkInParticipantSubevent(event.value, participant._id);
-		}
-		return false;
-	};
 
 	return (
 		<ContentLayout>
@@ -37,9 +21,6 @@ function Events() {
 				options={options}
 				statusType={loadingEvents ? "loading" : undefined}
 			/>
-			{/* {event && !loadingParticipants && (
-				<SubeventCheckin participants={participants} onConfirm={onConfirm} />
-			)} */}
 		</ContentLayout>
 	);
 }

--- a/apps/site/src/app/admin/events/Events.tsx
+++ b/apps/site/src/app/admin/events/Events.tsx
@@ -37,9 +37,9 @@ function Events() {
 				options={options}
 				statusType={loadingEvents ? "loading" : undefined}
 			/>
-			{event && !loadingParticipants && (
+			{/* {event && !loadingParticipants && (
 				<SubeventCheckin participants={participants} onConfirm={onConfirm} />
-			)}
+			)} */}
 		</ContentLayout>
 	);
 }

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -2,9 +2,12 @@
 
 import { useRouter, usePathname } from "next/navigation";
 
-import { PropsWithChildren, ReactNode, useEffect, useState } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 
 import AppLayout from "@cloudscape-design/components/app-layout";
+import Flashbar, {
+	FlashbarProps,
+} from "@cloudscape-design/components/flashbar";
 import axios from "axios";
 import { SWRConfig } from "swr";
 
@@ -20,7 +23,9 @@ function AdminLayout({ children }: PropsWithChildren) {
 	const identity = useUserIdentityStatic();
 	const router = useRouter();
 	const pathName = usePathname();
-	const [notifications, setNotifications] = useState<ReactNode[]>([]);
+	const [notifications, setNotifications] = useState<
+		FlashbarProps.MessageDefinition[]
+	>([]);
 
 	useEffect(() => {
 		setNotifications(() => []);
@@ -53,14 +58,27 @@ function AdminLayout({ children }: PropsWithChildren) {
 			}}
 		>
 			<UserContext.Provider value={identity}>
-				<NotificationContext.Provider
-					value={{ notifications, setNotifications }}
-				>
+				<NotificationContext.Provider value={{ setNotifications }}>
 					<AppLayout
 						content={children}
 						navigation={<AdminSidebar />}
 						breadcrumbs={<Breadcrumbs />}
-						notifications={notifications}
+						notifications={
+							<Flashbar
+								items={notifications}
+								i18nStrings={{
+									ariaLabel: "Notifications",
+									notificationBarAriaLabel: "View all notifications",
+									notificationBarText: "Notifications",
+									errorIconAriaLabel: "Error",
+									warningIconAriaLabel: "Warning",
+									successIconAriaLabel: "Success",
+									infoIconAriaLabel: "Info",
+									inProgressIconAriaLabel: "In progress",
+								}}
+								stackItems
+							/>
+						}
 					/>
 				</NotificationContext.Provider>
 			</UserContext.Provider>

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, ReactNode, useEffect, useState } from "react";
 
 import AppLayout from "@cloudscape-design/components/app-layout";
 import axios from "axios";
@@ -10,6 +10,7 @@ import { SWRConfig } from "swr";
 
 import { hasAdminRole } from "@/lib/admin/authorization";
 import UserContext from "@/lib/admin/UserContext";
+import NotificationContext from "@/lib/admin/NotificationContext";
 import useUserIdentityStatic from "@/lib/admin/useUserIdentityStatic";
 
 import AdminSidebar from "./AdminSidebar";
@@ -18,6 +19,12 @@ import Breadcrumbs from "./Breadcrumbs";
 function AdminLayout({ children }: PropsWithChildren) {
 	const identity = useUserIdentityStatic();
 	const router = useRouter();
+	const pathName = usePathname();
+	const [notifications, setNotifications] = useState<ReactNode[]>([]);
+
+	useEffect(() => {
+		setNotifications(() => []);
+	}, [pathName]);
 
 	if (!identity) {
 		return "Loading...";
@@ -46,11 +53,16 @@ function AdminLayout({ children }: PropsWithChildren) {
 			}}
 		>
 			<UserContext.Provider value={identity}>
-				<AppLayout
-					content={children}
-					navigation={<AdminSidebar />}
-					breadcrumbs={<Breadcrumbs />}
-				/>
+				<NotificationContext.Provider
+					value={{ notifications, setNotifications }}
+				>
+					<AppLayout
+						content={children}
+						navigation={<AdminSidebar />}
+						breadcrumbs={<Breadcrumbs />}
+						notifications={notifications}
+					/>
+				</NotificationContext.Provider>
 			</UserContext.Provider>
 		</SWRConfig>
 	);

--- a/apps/site/src/app/admin/participants/components/CheckInModal.tsx
+++ b/apps/site/src/app/admin/participants/components/CheckInModal.tsx
@@ -1,13 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
-import Input from "@cloudscape-design/components/input";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import TextContent from "@cloudscape-design/components/text-content";
 
-import BadgeScanner from "@/lib/admin/BadgeScanner";
 import { Participant } from "@/lib/admin/useParticipants";
 
 export interface ActionModalProps {
@@ -17,26 +15,7 @@ export interface ActionModalProps {
 }
 
 function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
-	const [badgeNumber, setBadgeNumber] = useState(
-		participant?.badge_number ?? "",
-	);
 	const [showScanner, setShowScanner] = useState(true);
-
-	const onScanSuccess = useCallback((decodedText: string) => {
-		setBadgeNumber(decodedText);
-		setShowScanner(false);
-	}, []);
-
-	useEffect(() => {
-		console.log("new participant", participant);
-		setBadgeNumber(participant?.badge_number ?? "");
-		setShowScanner(participant?.badge_number === null);
-	}, [participant]);
-
-	const badgeScanner = useMemo(
-		() => <BadgeScanner onSuccess={onScanSuccess} onError={() => null} />,
-		[onScanSuccess],
-	);
 
 	if (participant === null) {
 		if (showScanner) {
@@ -55,15 +34,7 @@ function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
 						<Button variant="link" onClick={onDismiss}>
 							Cancel
 						</Button>
-						<Button
-							variant="primary"
-							onClick={() =>
-								onConfirm({
-									...participant,
-									badge_number: badgeNumber,
-								})
-							}
-						>
+						<Button variant="primary" onClick={() => onConfirm(participant)}>
 							Check In
 						</Button>
 					</SpaceBetween>
@@ -71,30 +42,14 @@ function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
 			}
 			header={`Check In ${participant?.first_name} ${participant?.last_name}`}
 		>
-			<SpaceBetween size="m">
-				<TextContent>
-					<ul>
-						{/* TODO: actual instructions for check-in associates */}
-						<li>Ask for a photo ID and verify name is under attendee list.</li>
-						<li>Have participant sign the SPFB sheet.</li>
-						<li>Scan badge barcode with webcam or type in digits.</li>
-						<li>Fill in badge and give to participant.</li>
-					</ul>
-				</TextContent>
-				{showScanner && badgeScanner}
-				<SpaceBetween direction="horizontal" size="xs">
-					<Input
-						onChange={({ detail }) => setBadgeNumber(detail.value)}
-						value={badgeNumber}
-					/>
-					<Button
-						iconName="video-on"
-						variant="icon"
-						onClick={() => setShowScanner(true)}
-						iconAlt="Scan with camera"
-					/>
-				</SpaceBetween>
-			</SpaceBetween>
+			<TextContent>
+				<ul>
+					{/* TODO: actual instructions for check-in associates */}
+					<li>Ask for a photo ID and verify name is under attendee list.</li>
+					<li>Have participant sign the SPFB sheet.</li>
+					<li>Fill in badge and give to participant.</li>
+				</ul>
+			</TextContent>
 		</Modal>
 	);
 }

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -20,9 +20,9 @@ import ParticipantsFilters from "./ParticipantsFilters";
 import RoleBadge from "./RoleBadge";
 import SearchScannerModal from "./SearchScannerModal";
 
-const FRIDAY = new Date("2024-01-26T12:00:00");
-const SATURDAY = new Date("2024-01-27T12:00:00");
-const SUNDAY = new Date("2024-01-28T12:00:00");
+const FRIDAY = new Date("2025-01-24T12:00:00");
+const SATURDAY = new Date("2025-01-25T12:00:00");
+const SUNDAY = new Date("2025-01-26T12:00:00");
 
 interface EmptyStateProps {
 	title: string;

--- a/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantsTable.tsx
@@ -45,7 +45,6 @@ const SEARCHABLE_COLUMNS: (keyof Participant)[] = [
 	"last_name",
 	"roles",
 	"status",
-	"badge_number",
 ];
 
 type StrictColumnDefinition = TableProps.ColumnDefinition<Participant> & {
@@ -91,7 +90,6 @@ function ParticipantsTable({
 			"lastName",
 			"roles",
 			"status",
-			"badgeNumber",
 			"friday",
 			"saturday",
 			"sunday",
@@ -211,13 +209,6 @@ function ParticipantsTable({
 			cell: ApplicantStatus,
 			ariaLabel: createLabelFunction("status"),
 			sortingField: "status",
-		},
-		{
-			id: "badgeNumber",
-			header: "Badge Number",
-			cell: (item: Participant) => item.badge_number,
-			ariaLabel: createLabelFunction("Badge Number"),
-			sortingField: "badge_number",
 		},
 		{
 			id: "friday",

--- a/apps/site/src/lib/admin/NotificationContext.ts
+++ b/apps/site/src/lib/admin/NotificationContext.ts
@@ -1,13 +1,13 @@
-import { createContext, ReactNode, SetStateAction, Dispatch } from "react";
+import { FlashbarProps } from "@cloudscape-design/components";
+import { createContext, SetStateAction, Dispatch } from "react";
 
 interface Notification {
-	notifications: ReactNode[] | null;
-	setNotifications: Dispatch<SetStateAction<ReactNode[]>> | null;
+	setNotifications: Dispatch<
+		SetStateAction<FlashbarProps.MessageDefinition[]>
+	> | null;
 }
 
-type x = Dispatch<SetStateAction<ReactNode[]>>;
 const NotificationContext = createContext<Notification>({
-	notifications: null,
 	setNotifications: null,
 });
 

--- a/apps/site/src/lib/admin/NotificationContext.ts
+++ b/apps/site/src/lib/admin/NotificationContext.ts
@@ -1,0 +1,14 @@
+import { createContext, ReactNode, SetStateAction, Dispatch } from "react";
+
+interface Notification {
+	notifications: ReactNode[] | null;
+	setNotifications: Dispatch<SetStateAction<ReactNode[]>> | null;
+}
+
+type x = Dispatch<SetStateAction<ReactNode[]>>;
+const NotificationContext = createContext<Notification>({
+	notifications: null,
+	setNotifications: null,
+});
+
+export default NotificationContext;

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -31,10 +31,7 @@ function useParticipants() {
 		// TODO: implement mutation for showing checked in on each day
 		// Note: Will cause 422 if badge number is null, but in practice,
 		// this should never happen
-		await axios.post(
-			`/api/admin/checkin/${participant._id}`,
-			participant.badge_number,
-		);
+		await axios.post(`/api/admin/checkin/${participant._id}`);
 		mutate();
 	};
 


### PR DESCRIPTION
## Changes

- Hides badge number from participants table used for check-in
  - Note: `badge_number` is still part of the class `Participant` and list `PARTICIPANT_FIELDS`
- Removes badge scanning and badge number entry in confirmation check-in modal
- Also removes badge scanning and badge number entry for Event check-ins
  - Note: For IH 25, event check-ins will not be done through our site
- Sets up notifications system and clears all notifications on page change
- Notifications will be pushed to the notifications system as Flashbars that show at the top of the admin layout

## Testing

1. Ensure you can see the participant table and be able to check-in people. 
2. Upon clicking "Check In" in the confirmation check-in modal, notice that a new Flashbar gets added to the top of the screen as part of the notifications Flashbar system 


Closes #593 and closes #407 