### PR TITLE
Allow Organizers to check in workshop leads if they have other roles

### DIFF
--- a/apps/api/src/admin/participant_manager.py
+++ b/apps/api/src/admin/participant_manager.py
@@ -14,9 +14,7 @@ log = getLogger(__name__)
 
 Checkin: TypeAlias = tuple[datetime, str]
 
-NON_HACKER_ROLES = (
-    Role.MENTOR,
-    Role.VOLUNTEER,
+OUTSIDE_ROLES = (
     Role.SPONSOR,
     Role.JUDGE,
     Role.WORKSHOP_LEAD,
@@ -111,12 +109,12 @@ async def check_in_participant(uid: str, associate: User) -> None:
     log.info(f"Applicant {uid} checked in by {associate.uid}")
 
 
-async def confirm_attendance_non_hacker(uid: str, director: User) -> None:
-    """Update status from WAIVER_SIGNED to ATTENDING for non-hackers."""
+async def confirm_attendance_outside_participants(uid: str, director: User) -> None:
+    """Update status from WAIVER_SIGNED to ATTENDING for outside participants."""
 
     record: Optional[dict[str, object]] = await mongodb_handler.retrieve_one(
         Collection.USERS,
-        {"_id": uid, "roles": {"$in": NON_HACKER_ROLES}},
+        {"_id": uid, "roles": {"$in": OUTSIDE_ROLES}},
         ["status"],
     )
 

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -363,9 +363,9 @@ async def update_attendance(
         User, Depends(require_role({Role.DIRECTOR, Role.CHECKIN_LEAD}))
     ],
 ) -> None:
-    """Update status to Role.ATTENDING for non-hackers."""
+    """Update status to Role.ATTENDING for outside participants."""
     try:
-        await participant_manager.confirm_attendance_non_hacker(uid, director)
+        await participant_manager.confirm_attendance_outside_participants(uid, director)
     except ValueError:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     except RuntimeError as err:

--- a/apps/site/src/app/admin/participants/Participants.tsx
+++ b/apps/site/src/app/admin/participants/Participants.tsx
@@ -15,7 +15,7 @@ function Participants() {
 		loading,
 		checkInParticipant,
 		releaseParticipantFromWaitlist,
-		confirmNonHacker,
+		confirmOutsideParticipants,
 	} = useParticipants();
 	const [checkinParticipant, setCheckinParticipant] =
 		useState<Participant | null>(null);
@@ -129,7 +129,7 @@ function Participants() {
 				loading={loading}
 				initiateCheckIn={initiateCheckIn}
 				initiatePromotion={initiatePromotion}
-				initiateConfirm={confirmNonHacker}
+				initiateConfirm={confirmOutsideParticipants}
 			/>
 			<CheckInModal
 				onDismiss={() => setCheckinParticipant(null)}

--- a/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
+++ b/apps/site/src/app/admin/participants/components/ParticipantAction.tsx
@@ -9,10 +9,25 @@ import { ParticipantRole, ReviewStatus, Status } from "@/lib/userRecord";
 
 import ParticipantActionPopover from "./ParticipantActionPopover";
 
-const OUTSIDE_ROLES = [ParticipantRole.Judge, ParticipantRole.Sponsor];
+const JUDGE_SPONSOR_ROLES = [ParticipantRole.Judge, ParticipantRole.Sponsor];
+const HACKER_MENTOR_VOLUNTEER_ROLES = [
+	ParticipantRole.Hacker,
+	ParticipantRole.Mentor,
+	ParticipantRole.Volunteer,
+];
 
-export function isOutsideParticipant(roles: ReadonlyArray<ParticipantRole>) {
-	return roles.some((role) => OUTSIDE_ROLES.includes(role));
+export function isJudgeSponsorParticipant(
+	roles: ReadonlyArray<ParticipantRole>,
+) {
+	return roles.some((role) => JUDGE_SPONSOR_ROLES.includes(role));
+}
+
+function isWorkshopLead(roles: ReadonlyArray<ParticipantRole>) {
+	return roles.includes(ParticipantRole.WorkshopLead);
+}
+
+function isHackerMentorVolunteer(roles: ReadonlyArray<ParticipantRole>) {
+	return roles.some((role) => HACKER_MENTOR_VOLUNTEER_ROLES.includes(role));
 }
 
 interface ParticipantActionProps {
@@ -33,7 +48,9 @@ function ParticipantAction({
 	const canPromote = isCheckInLead(roles);
 	const isWaiverSigned = participant.status === Status.signed;
 	const isAccepted = participant.status === Status.accepted;
-	const outsideParticipant = isOutsideParticipant(participant.roles);
+	const judgeSponsorParticipant = isJudgeSponsorParticipant(participant.roles);
+	const hackerMentorVolunteer = isHackerMentorVolunteer(participant.roles);
+	const workshopLead = isWorkshopLead(participant.roles);
 
 	const promoteButton = (
 		<Button
@@ -68,9 +85,9 @@ function ParticipantAction({
 		</Button>
 	);
 
-	if (outsideParticipant) {
+	if (judgeSponsorParticipant) {
 		const content = !canPromote
-			? "Only check-in leads can confirm outside participants."
+			? "Only check-in leads can confirm judges and sponsors."
 			: "Must sign waiver first.";
 		if (!canPromote || participant.status === ReviewStatus.reviewed) {
 			return (
@@ -91,7 +108,7 @@ function ParticipantAction({
 			);
 		}
 		return promoteButton;
-	} else if (isWaiverSigned || isAccepted) {
+	} else if (hackerMentorVolunteer && (isWaiverSigned || isAccepted)) {
 		const content = isWaiverSigned
 			? "Must confirm attendance in portal first"
 			: "Must sign waiver and confirm attendance in portal";
@@ -100,6 +117,21 @@ function ParticipantAction({
 				{checkinButton}
 			</ParticipantActionPopover>
 		);
+	} else if (!hackerMentorVolunteer && workshopLead) {
+		// participants that are just workshop leads
+		const content = !canPromote
+			? "Only check-in leads can confirm workshop leads without any other roles."
+			: "Must sign waiver first.";
+		if (!canPromote || participant.status === ReviewStatus.reviewed) {
+			return (
+				<ParticipantActionPopover content={content}>
+					{confirmButton}
+				</ParticipantActionPopover>
+			);
+		} else if (participant.status === Status.signed) {
+			return confirmButton;
+		}
+		return checkinButton;
 	}
 	return checkinButton;
 }

--- a/apps/site/src/lib/admin/useParticipants.ts
+++ b/apps/site/src/lib/admin/useParticipants.ts
@@ -42,8 +42,8 @@ function useParticipants() {
 		mutate();
 	};
 
-	const confirmNonHacker = async (participant: Participant) => {
-		console.log("Confirmed attendance for non-hacker", participant);
+	const confirmOutsideParticipants = async (participant: Participant) => {
+		console.log("Confirmed attendance for outside participants", participant);
 		await axios.post(`/api/admin/update-attendance/${participant._id}`);
 		mutate();
 	};
@@ -54,7 +54,7 @@ function useParticipants() {
 		error,
 		checkInParticipant,
 		releaseParticipantFromWaitlist,
-		confirmNonHacker,
+		confirmOutsideParticipants,
 	};
 }
 


### PR DESCRIPTION
## Changes
- Due to a somewhat not uncommon occurrence where participants are both hackers and workshop leads, we should allow any check-in worker check them in