### PR TITLE
Created middleware and changed mongodb_handler to handle multiple databases

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.key
 .coverage
 lib
+.docker

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -4,6 +4,7 @@ import os
 from fastapi import FastAPI, Request
 
 from routers import admin, director, guest, saml, user
+from utils.hackathon_context import hackathon_name_ctx
 
 logging.basicConfig(level=logging.INFO)
 
@@ -32,9 +33,6 @@ async def root() -> dict[str, str]:
 
 
 @app.middleware("http")
-async def set_db_name_from_header(request: Request, call_next):
-    # db_name_ctx.set(request.headers.get("X-Database-Name"))
-    print("Setting db name from header")
-    print(request.headers.get("X-Hackathon-Name"))
-    print("--------------------------------")
+async def set_hackathon_name_context_from_header(request: Request, call_next):
+    hackathon_name_ctx.set(request.headers.get("X-Hackathon-Name"))
     return await call_next(request)

--- a/apps/api/src/app.py
+++ b/apps/api/src/app.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from routers import admin, director, guest, saml, user
 
@@ -29,3 +29,12 @@ app.include_router(director.router, prefix="/director", tags=["director"])
 @app.get("/")
 async def root() -> dict[str, str]:
     return {"message": "hello"}
+
+
+@app.middleware("http")
+async def set_db_name_from_header(request: Request, call_next):
+    # db_name_ctx.set(request.headers.get("X-Database-Name"))
+    print("Setting db name from header")
+    print(request.headers.get("X-Hackathon-Name"))
+    print("--------------------------------")
+    return await call_next(request)

--- a/apps/api/src/services/mongodb_handler.py
+++ b/apps/api/src/services/mongodb_handler.py
@@ -5,8 +5,8 @@ from logging import getLogger
 from typing import Any, Mapping, Optional, Union
 
 from bson import CodecOptions
-from motor.core import AgnosticClient
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
+from motor.core import AgnosticClient, AgnosticDatabase
+from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import BaseModel, ConfigDict, Field
 
 from utils.hackathon_context import hackathon_name_ctx
@@ -49,7 +49,7 @@ class Collection(str, Enum):
     EMAILS = "emails"
 
 
-def get_database() -> AsyncIOMotorDatabase:
+def get_database() -> AgnosticDatabase[Any]:
     hackathon_name = hackathon_name_ctx.get()
     if hackathon_name == "irvinehacks":
         database_name = IRVINE_HACKS_DATABASE_NAME

--- a/apps/api/src/utils/hackathon_context.py
+++ b/apps/api/src/utils/hackathon_context.py
@@ -1,3 +1,3 @@
 import contextvars
 
-hackathon_name_ctx = contextvars.ContextVar("hackathon_name", default=None)
+hackathon_name_ctx = contextvars.ContextVar("hackathon_name", default="")

--- a/apps/api/src/utils/hackathon_context.py
+++ b/apps/api/src/utils/hackathon_context.py
@@ -1,0 +1,3 @@
+import contextvars
+
+hackathon_name_ctx = contextvars.ContextVar("hackathon_name", default=None)

--- a/apps/api/tests/test_app.py
+++ b/apps/api/tests/test_app.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from app import app
 
 client = TestClient(app)
+client.headers.update({"X-Hackathon-Name": "irvinehacks"})
 
 
 def test_user_identity_accessible() -> None:

--- a/apps/api/tests/test_guest_auth.py
+++ b/apps/api/tests/test_guest_auth.py
@@ -41,9 +41,9 @@ def test_can_validate_key() -> None:
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
 async def test_get_existing_unexpired_key(mock_mongodb_retrieve_one: AsyncMock) -> None:
     """Test that existing, unexpired guest authorization key can be retrieved."""
-    iat = datetime(2024, 1, 11)
+    iat = datetime(2025, 1, 11)
     exp = datetime(
-        2025, 7, 1, tzinfo=timezone.utc
+        2026, 7, 1, tzinfo=timezone.utc
     )  # update expire date for this test to not fail :)
     # this test will fail next year :P
     mock_mongodb_retrieve_one.return_value = {

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -16,7 +16,10 @@ async def test_insert_document_success(mock_DB: MagicMock) -> None:
     mock_collection.insert_one.return_value = InsertOneResult(
         "my-id", acknowledged=True
     )
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     data = {"_id": "my-id", "email": "hack@uci.edu"}
     result = await mongodb_handler.insert(Collection.TESTING, data)
@@ -30,7 +33,10 @@ async def test_insert_document_failure(mock_DB: MagicMock) -> None:
     """Test that a lack of write acknowledgement of insertion causes a RuntimeError"""
     mock_collection = AsyncMock()
     mock_collection.insert_one.return_value = InsertOneResult("", acknowledged=False)
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     data = {"_id": "my-id", "email": "hack@uci.edu"}
     with pytest.raises(RuntimeError):
@@ -43,7 +49,10 @@ async def test_retrieve_one_existing_document(mock_DB: MagicMock) -> None:
     """Test that single existing document can be retrieved"""
     mock_collection = AsyncMock()
     mock_collection.find_one.return_value = SAMPLE_DOCUMENT
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     query = {"_id": "my-id"}
     result = await mongodb_handler.retrieve_one(Collection.TESTING, query)
@@ -63,7 +72,10 @@ async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
     mock_cursor = AsyncMock()
     mock_cursor.to_list.return_value = SAMPLE_DOCUMENTS
     mock_collection.find.return_value = mock_cursor
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     query = {"roles": "Hacker"}
     result = await mongodb_handler.retrieve(Collection.TESTING, query)
@@ -82,7 +94,10 @@ async def test_update_existing_document(mock_DB: MagicMock) -> None:
         },
         True,
     )
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     query = {"_id": "my-id"}
     update = {"name": "hack"}
@@ -104,7 +119,10 @@ async def test_upsert_existing_document(mock_DB: MagicMock) -> None:
         },
         True,
     )
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     query = {"_id": "my-id"}
     update = {"status": "accepted"}
@@ -122,7 +140,10 @@ async def test_update_existing_document_failure(mock_DB: MagicMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()
     mock_collection.update_one.return_value = UpdateResult(dict(), False)
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     with pytest.raises(RuntimeError):
         query = {"_id": "my-id"}
@@ -143,7 +164,10 @@ async def test_update_existing_documents(mock_DB: MagicMock) -> None:
         },
         True,
     )
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = MagicMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     query = {"_id": "my-id"}
     update = {"status": "ACCEPTED"}

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -9,7 +9,7 @@ from services.mongodb_handler import Collection
 SAMPLE_DOCUMENT = {"_id": "my-id", "email": "hack@uci.edu"}
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_insert_document_success(mock_DB: MagicMock) -> None:
     """Test that inserting a document successfully returns the document id"""
     mock_collection = AsyncMock()
@@ -25,7 +25,7 @@ async def test_insert_document_success(mock_DB: MagicMock) -> None:
     assert result == "my-id"
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_insert_document_failure(mock_DB: MagicMock) -> None:
     """Test that a lack of write acknowledgement of insertion causes a RuntimeError"""
     mock_collection = AsyncMock()
@@ -38,7 +38,7 @@ async def test_insert_document_failure(mock_DB: MagicMock) -> None:
         mock_collection.insert_one.assert_awaited_once_with(data)
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_retrieve_one_existing_document(mock_DB: MagicMock) -> None:
     """Test that single existing document can be retrieved"""
     mock_collection = AsyncMock()
@@ -51,7 +51,7 @@ async def test_retrieve_one_existing_document(mock_DB: MagicMock) -> None:
     assert result == SAMPLE_DOCUMENT
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
     """Test that multiple existing documents can be retrieved"""
     SAMPLE_DOCUMENTS = [
@@ -71,7 +71,7 @@ async def test_retrieve_existing_documents(mock_DB: MagicMock) -> None:
     assert result == SAMPLE_DOCUMENTS
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_update_existing_document(mock_DB: MagicMock) -> None:
     """Test that single existing document can be updated"""
     mock_collection = AsyncMock()
@@ -93,7 +93,7 @@ async def test_update_existing_document(mock_DB: MagicMock) -> None:
     assert result is True
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_upsert_existing_document(mock_DB: MagicMock) -> None:
     """Test that single existing document can be upserted"""
     mock_collection = AsyncMock()
@@ -117,7 +117,7 @@ async def test_upsert_existing_document(mock_DB: MagicMock) -> None:
     assert result is True
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_update_existing_document_failure(mock_DB: MagicMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()
@@ -132,7 +132,7 @@ async def test_update_existing_document_failure(mock_DB: MagicMock) -> None:
         )
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_update_existing_documents(mock_DB: MagicMock) -> None:
     """Test that multiple existing documents can be updated"""
     mock_collection = AsyncMock()
@@ -152,7 +152,7 @@ async def test_update_existing_documents(mock_DB: MagicMock) -> None:
     assert result is True
 
 
-@patch("services.mongodb_handler.DB")
+@patch("services.mongodb_handler.get_database")
 async def test_update_existing_documents_failure(mock_DB: MagicMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -152,8 +152,8 @@ async def test_update_existing_documents(mock_DB: MagicMock) -> None:
     assert result is True
 
 
-@patch("services.mongodb_handler.get_database")
-async def test_update_existing_documents_failure(mock_DB: MagicMock) -> None:
+@patch("services.mongodb_handler.get_database", new_callable=AsyncMock)
+async def test_update_existing_documents_failure(mock_DB: AsyncMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()
     mock_collection.update_many.return_value = UpdateResult(dict(), False)

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -157,7 +157,10 @@ async def test_update_existing_documents_failure(mock_DB: AsyncMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()
     mock_collection.update_many.return_value = UpdateResult(dict(), False)
-    mock_DB.__getitem__.return_value = mock_collection
+    mock_db_instance = AsyncMock()
+    mock_db_instance.__getitem__.return_value = mock_collection
+
+    mock_DB.return_value = mock_db_instance
 
     update = {"status": "ACCEPTED"}
     with pytest.raises(RuntimeError):

--- a/apps/api/tests/test_mongodb_handler.py
+++ b/apps/api/tests/test_mongodb_handler.py
@@ -152,12 +152,12 @@ async def test_update_existing_documents(mock_DB: MagicMock) -> None:
     assert result is True
 
 
-@patch("services.mongodb_handler.get_database", new_callable=AsyncMock)
-async def test_update_existing_documents_failure(mock_DB: AsyncMock) -> None:
+@patch("services.mongodb_handler.get_database")
+async def test_update_existing_documents_failure(mock_DB: MagicMock) -> None:
     """Test that lack of acknowledgement during update causes RuntimeError"""
     mock_collection = AsyncMock()
     mock_collection.update_many.return_value = UpdateResult(dict(), False)
-    mock_db_instance = AsyncMock()
+    mock_db_instance = MagicMock()
     mock_db_instance.__getitem__.return_value = mock_collection
 
     mock_DB.return_value = mock_db_instance

--- a/apps/site/src/lib/utils/api.ts
+++ b/apps/site/src/lib/utils/api.ts
@@ -17,6 +17,7 @@ api.interceptors.request.use((config) => {
 	const provided = config.headers.get("Cookie");
 	const newCookies = (provided ? `${provided}; ` : "") + cookieStore.toString();
 	config.headers.set("Cookie", newCookies);
+	config.headers.set("X-Hackathon-Name", "irvinehacks");
 
 	return config;
 });

--- a/apps/site/src/middleware.ts
+++ b/apps/site/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+	const requestHeaders = new Headers(request.headers);
+	requestHeaders.set("X-Hackathon-Name", "irvinehacks");
+
+	return NextResponse.next({
+		request: {
+			headers: requestHeaders,
+		},
+	});
+}
+
+export const config = {
+	matcher: ["/api/:path*"],
+};


### PR DESCRIPTION
Closes #619 
Closes #620 
Closes #621 

## Changes
- FastAPI
  - `app.py`
    - Added middleware to FastAPI app
    - Sets context from `X-Hackathon-Name` header
  - `mongodb_handler.py`
    - Created `get_database` function to get database based on context value
    - For each function, called `get_database` before performing operations
  - `hackathon_context`
    - Only purpose is to provide context value
    - In the future, use this context value for things like #623 
- NextJS
  - `api.ts`
    - This is a server-side function, so header needs to be set here separately.
  - `middleware.ts`
    - This is for every client-side request that starts with `/api/`, so header needs to be set here separately.

## Testing
Add print statement to FastAPI middleware like:
```python
@app.middleware("http")
async def set_hackathon_name_context_from_header(request: Request, call_next):
    hackathon_name_ctx.set(request.headers.get("X-Hackathon-Name"))
    print("middleware works")
    print("hackathon_name_ctx.get())
    return await call_next(request)
```

- Server-side api call
  - Loading the site should run `getUserIdentity`, which should hit the middleware and print
- Client-side api call
 Add some way to call axios in a client component, which should hit the middleware and print. I created a button in `CharacterBox.tsx`  for this:
```typescript
<button type="button" onClick={() => {
	axios.get("/api/admin/set-hackathon-name");
}}>
	Set Hackathon Name
</button>
```
