### PR TITLE
[Portal] Updated ZH mentor models and fixed application flow

### DIFF
--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -261,7 +261,6 @@ def get_raw_mentor_discriminator_value(v: Any) -> str:
     return ""
 
 
-# Add this discriminated union
 RawMentorApplicationDataUnion = Annotated[
     Union[
         Annotated[RawMentorApplicationData, Tag("mentor")],

--- a/apps/api/src/models/ApplicationData.py
+++ b/apps/api/src/models/ApplicationData.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any, Literal, Union
 
-from fastapi import Form, UploadFile
+from fastapi import UploadFile
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -140,7 +140,7 @@ class RawHackerApplicationData(BaseApplicationData):
 class RawMentorApplicationData(BaseMentorApplicationData):
     """Expected to be sent by the form on the site."""
 
-    first_name: str = Form(...)
+    first_name: str
     last_name: str
     resume: UploadFile
     application_type: Literal["Mentor"]

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -102,18 +102,18 @@ async def apply(
     raw_application_data: Annotated[
         RawHackerApplicationData, Form(media_type="multipart/form-data")
     ],
-) -> RedirectResponse:
+) -> str:
     return await _apply_flow(user, raw_application_data)
 
 
 @router.post("/mentor")
 async def mentor(
     user: Annotated[User, Depends(require_user_identity)], request: Request
-) -> RedirectResponse:
+) -> str:
     form = await request.form()
     data = _parsed_form(form)
 
-    # Manually usediscriminator function
+    # Use your discriminator function
     discriminator = get_raw_mentor_discriminator_value(data)
     raw_application_data: Union[
         RawMentorApplicationData, RawZotHacksMentorApplicationData
@@ -132,7 +132,7 @@ async def mentor(
 async def volunteer(
     user: Annotated[User, Depends(require_user_identity)],
     raw_application_data: Annotated[RawVolunteerApplicationData, Form()],
-) -> RedirectResponse:
+) -> str:
     return await _apply_flow(user, raw_application_data)
 
 
@@ -144,7 +144,7 @@ async def _apply_flow(
         RawVolunteerApplicationData,
         RawZotHacksMentorApplicationData,
     ],
-) -> RedirectResponse:
+) -> str:
     """Common flow for all three types of applications."""
     # Check if current datetime is past application deadline
     now = datetime.now(timezone.utc)
@@ -252,7 +252,10 @@ async def _apply_flow(
     # TODO: handle inconsistent results if one service fails
 
     log.info("%s submitted an application", user.uid)
-    return RedirectResponse(URL(path="/portal"), status.HTTP_303_SEE_OTHER)
+    return (
+        "Thank you for submitting an application to IrvineHacks 2025! Please "
+        + "visit https://irvinehacks.com/portal to see your application status."
+    )
 
 
 @router.get("/waiver")

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -102,18 +102,18 @@ async def apply(
     raw_application_data: Annotated[
         RawHackerApplicationData, Form(media_type="multipart/form-data")
     ],
-) -> str:
+) -> RedirectResponse:
     return await _apply_flow(user, raw_application_data)
 
 
 @router.post("/mentor")
 async def mentor(
     user: Annotated[User, Depends(require_user_identity)], request: Request
-) -> str:
+) -> RedirectResponse:
     form = await request.form()
     data = _parsed_form(form)
 
-    # Use your discriminator function
+    # Manually usediscriminator function
     discriminator = get_raw_mentor_discriminator_value(data)
     raw_application_data: Union[
         RawMentorApplicationData, RawZotHacksMentorApplicationData
@@ -132,7 +132,7 @@ async def mentor(
 async def volunteer(
     user: Annotated[User, Depends(require_user_identity)],
     raw_application_data: Annotated[RawVolunteerApplicationData, Form()],
-) -> str:
+) -> RedirectResponse:
     return await _apply_flow(user, raw_application_data)
 
 
@@ -144,7 +144,7 @@ async def _apply_flow(
         RawVolunteerApplicationData,
         RawZotHacksMentorApplicationData,
     ],
-) -> str:
+) -> RedirectResponse:
     """Common flow for all three types of applications."""
     # Check if current datetime is past application deadline
     now = datetime.now(timezone.utc)
@@ -252,10 +252,7 @@ async def _apply_flow(
     # TODO: handle inconsistent results if one service fails
 
     log.info("%s submitted an application", user.uid)
-    return (
-        "Thank you for submitting an application to IrvineHacks 2025! Please "
-        + "visit https://irvinehacks.com/portal to see your application status."
-    )
+    return RedirectResponse(URL(path="/portal"), status.HTTP_303_SEE_OTHER)
 
 
 @router.get("/waiver")

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -17,6 +17,7 @@ from models.ApplicationData import (
     RawHackerApplicationData,
     RawMentorApplicationData,
     RawVolunteerApplicationData,
+    RawZotHacksMentorApplicationData,
 )
 from models.user_record import Applicant, BareApplicant, Role, Status
 from services import docusign_handler, mongodb_handler
@@ -28,7 +29,7 @@ log = getLogger(__name__)
 
 router = APIRouter()
 
-DEADLINE = datetime(2025, 1, 13, 8, 1, tzinfo=timezone.utc)
+DEADLINE = datetime(2025, 8, 13, 8, 1, tzinfo=timezone.utc)
 
 
 class IdentityResponse(BaseModel):
@@ -118,7 +119,10 @@ async def volunteer(
 async def _apply_flow(
     user: User,
     raw_application_data: Union[
-        RawHackerApplicationData, RawMentorApplicationData, RawVolunteerApplicationData
+        RawHackerApplicationData,
+        RawMentorApplicationData,
+        RawVolunteerApplicationData,
+        RawZotHacksMentorApplicationData,
     ],
 ) -> str:
     """Common flow for all three types of applications."""
@@ -158,7 +162,11 @@ async def _apply_flow(
             resume_url = await resume_handler.upload_resume(
                 # TODO: reexamine why adapter is needed
                 TypeAdapter(
-                    Union[RawHackerApplicationData, RawMentorApplicationData]
+                    Union[
+                        RawHackerApplicationData,
+                        RawMentorApplicationData,
+                        RawZotHacksMentorApplicationData,
+                    ]
                 ).validate_python(raw_application_data),
                 resume,
             )

--- a/apps/api/src/utils/dev_mock.py
+++ b/apps/api/src/utils/dev_mock.py
@@ -11,11 +11,23 @@ from fastapi.responses import RedirectResponse
 
 from services.sendgrid_handler import Template
 from utils import resume_handler
+from utils.hackathon_context import HackathonName
 
 log = getLogger(__name__)
 
 _HACKER_RESUMES_FOLDER_ID = "1a_Hacker_Resumes"
 _MENTOR_RESUMES_FOLDER_ID = "1b_Mentor_Resumes"
+
+_FOLDER_MAP = {
+    HackathonName.IRVINEHACKS: {
+        "Hacker": _HACKER_RESUMES_FOLDER_ID,
+        "Mentor": _MENTOR_RESUMES_FOLDER_ID,
+    },
+    HackathonName.ZOTHACKS: {
+        "Hacker": _HACKER_RESUMES_FOLDER_ID,
+        "Mentor": _MENTOR_RESUMES_FOLDER_ID,
+    },
+}
 
 
 def mock_set_cookie(self: RedirectResponse, *args: Any, **kwargs: Any) -> None:
@@ -73,6 +85,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         resume_handler,
         "IRVINEHACKS_MENTOR_RESUMES_FOLDER_ID",
         new=_MENTOR_RESUMES_FOLDER_ID,
+    ).start()
+    patch.object(
+        resume_handler,
+        "ZOTHACKS_HACKER_RESUMES_FOLDER_ID",
+        new=_HACKER_RESUMES_FOLDER_ID,
+    ).start()
+    patch.object(
+        resume_handler,
+        "ZOTHACKS_MENTOR_RESUMES_FOLDER_ID",
+        new=_MENTOR_RESUMES_FOLDER_ID,
+    ).start()
+
+    patch.object(
+        resume_handler,
+        "FOLDER_MAP",
+        new=_FOLDER_MAP,
     ).start()
 
     patch.object(RedirectResponse, "set_cookie", new=mock_set_cookie).start()

--- a/apps/api/src/utils/resume_handler.py
+++ b/apps/api/src/utils/resume_handler.py
@@ -45,6 +45,10 @@ async def upload_resume(person: Person, resume_upload: UploadFile) -> HttpUrl:
 
     hackathon_name = hackathon_name_ctx.get()
     RESUME_FOLDER_ID = FOLDER_MAP[hackathon_name][person.application_type]
+    print(person)
+    print(hackathon_name)
+    print(RESUME_FOLDER_ID)
+    print(person.application_type)
     if not RESUME_FOLDER_ID:
         raise RuntimeError("RESUMES_FOLDER_ID is not defined")
 

--- a/apps/api/src/utils/resume_handler.py
+++ b/apps/api/src/utils/resume_handler.py
@@ -45,10 +45,6 @@ async def upload_resume(person: Person, resume_upload: UploadFile) -> HttpUrl:
 
     hackathon_name = hackathon_name_ctx.get()
     RESUME_FOLDER_ID = FOLDER_MAP[hackathon_name][person.application_type]
-    print(person)
-    print(hackathon_name)
-    print(RESUME_FOLDER_ID)
-    print(person.application_type)
     if not RESUME_FOLDER_ID:
         raise RuntimeError("RESUMES_FOLDER_ID is not defined")
 

--- a/apps/api/tests/test_user_mentor_apply.py
+++ b/apps/api/tests/test_user_mentor_apply.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -263,7 +264,7 @@ def test_mentor_application_data_with_other_throws_422(
     mock_mongodb_handler_retrieve_one: AsyncMock,
 ) -> None:
     mock_mongodb_handler_retrieve_one.return_value = None
-    contains_other = SAMPLE_APPLICATION.copy()
+    contains_other = copy.deepcopy(SAMPLE_APPLICATION)
     contains_other["pronouns"].append("other")  # type: ignore[attr-defined]
     res = client.post("/mentor", data=contains_other, files=SAMPLE_FILES)
     assert res.status_code == 422


### PR DESCRIPTION
- Added ZotHacksMentor models
- Added discriminators to determine which model to use in `user.py`
- Mocked the correct folders for gdrive uploading
- Used deepcopy for test as before, it changed `SAMPLE_APPLICATION`


FastAPI can't determine the correct model to use in the following code, so I implemented the discriminated union myself.
```python
raw_application_data: Annotated[
    Union[RawZotHacksMentorApplicationData, RawMentorApplicationData], Form(media_type="multipart/form-data")
]
```

## Testing
- In the zothacks repo, checkout the `mentor-app-page` branch
- Run this repo, then make sure the zothacks repo env has `IH_BACKEND="localhost:8000"`, then run the zothacks repo locally
- For the zothacks local site (ex. `localhost:3001`), navigate to `/guest-login`
- Enter an email
- Enter the passphrase from the irvinehacks local console logs
  - It should look something like "Simulating GUEST_TOKEN"
- Fill out the application, including uploading a PDF
- You should get an string response