### PR TITLE
Corrected hackathon name in middleware

### DIFF
--- a/apps/site/src/middleware.ts
+++ b/apps/site/src/middleware.ts
@@ -18,7 +18,7 @@ export function middleware(request: NextRequest) {
 
 	const isAdminApi = pathname.startsWith("/admin");
 
-	let hackathon = request.headers.get("X-Hackathon-Name") || "zothacks";
+	let hackathon = request.headers.get("X-Hackathon-Name") || "irvinehacks";
 	if (isAdminApi) {
 		const selected = request.cookies.get("hackathon")?.value;
 		if (selected && ALLOWED_HACKATHONS.has(selected)) {


### PR DESCRIPTION
This is so the correct irvinehacks db is used instead of the zothacks db from before.