### PR TITLE
Adjusted "By" text for consistency

### DIFF
--- a/apps/site/src/app/(main)/schedule/components/EventCard.tsx
+++ b/apps/site/src/app/(main)/schedule/components/EventCard.tsx
@@ -51,9 +51,7 @@ export default function EventCard({
 							}`}</p>
 
 							{organization && (
-								<p className="text-2xl mt-0 mb-0">
-								By: {organization}
-								</p>
+								<p className="text-2xl mt-0 mb-0">By: {organization}</p>
 							)}
 						</div>
 					</div>


### PR DESCRIPTION
Moved the "By" organization text underneath the location and time
Changed the sizing of the text so that it remains consistent with the rest of the data

Closes #739 