### PR TITLE
Updated checkin instructions for Slack

### DIFF
--- a/apps/site/src/app/admin/participants/components/CheckInModal.tsx
+++ b/apps/site/src/app/admin/participants/components/CheckInModal.tsx
@@ -56,7 +56,8 @@ function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
 								</li>
 								<li>Have participant sign the SPFB sheet.</li>
 								<li>
-									Check if the participant has joined Slack (there is a column to indicate it). If not, ask a check-in lead to add them.
+									Check if the participant has joined Slack (there is a column
+									to indicate it). If not, ask a check-in lead to add them.
 								</li>
 								<li>Ask participant to fill in badge.</li>
 								<li>


### PR DESCRIPTION
<img width="1272" height="994" alt="CleanShot 2026-02-25 at 19 05 52@2x" src="https://github.com/user-attachments/assets/64d10956-b3d7-4136-b3fd-9af79ebf554b" />

Changed the line to 
> Check if the participant has joined Slack (there is a column to indicate it). If not, ask a check-in lead to help.

Since only check-in leads have admin on slack.