### PR TITLE
Check in Modal Confirmation and Warning

### DIFF
--- a/apps/site/src/app/admin/participants/Participants.tsx
+++ b/apps/site/src/app/admin/participants/Participants.tsx
@@ -19,6 +19,7 @@ function Participants() {
 	} = useParticipants();
 	const [checkinParticipant, setCheckinParticipant] =
 		useState<Participant | null>(null);
+	const [checkInConfirmed, setCheckInConfirmed] = useState(false);
 
 	const { setNotifications } = useContext(NotificationContext);
 
@@ -65,7 +66,7 @@ function Participants() {
 			} else if (type === "waitlisted") {
 				await queueParticipant(participant);
 			}
-			setCheckinParticipant(null);
+			setCheckInConfirmed(true);
 			if (setNotifications) {
 				const message =
 					type === "accepted"
@@ -135,9 +136,13 @@ function Participants() {
 				updateWaiverStatus={onUpdateWaiver}
 			/>
 			<CheckInModal
-				onDismiss={() => setCheckinParticipant(null)}
+				onDismiss={() => {
+					setCheckinParticipant(null);
+					setCheckInConfirmed(false);
+				}}
 				onConfirm={sendCheckIn}
 				participant={checkinParticipant}
+				checkInConfirmed={checkInConfirmed}
 			/>
 		</>
 	);

--- a/apps/site/src/app/admin/participants/components/CheckInModal.tsx
+++ b/apps/site/src/app/admin/participants/components/CheckInModal.tsx
@@ -36,10 +36,10 @@ function CheckInModal({
 	}
 
 	const handleDismiss = () => {
-		if (!checkInConfirmed) {
-			setShowExitWarning(true);
-		} else {
+		if (showExitWarning || checkInConfirmed) {
 			onDismiss();
+		} else {
+			setShowExitWarning(true);
 		}
 	};
 
@@ -95,7 +95,7 @@ function CheckInModal({
 			<SpaceBetween size="s">
 				{showExitWarning && (
 					<Alert type="warning">
-						You haven&apos;t checked in this user yet.
+						You haven&apos;t checked in this participant yet.
 					</Alert>
 				)}
 

--- a/apps/site/src/app/admin/participants/components/CheckInModal.tsx
+++ b/apps/site/src/app/admin/participants/components/CheckInModal.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Modal from "@cloudscape-design/components/modal";
@@ -13,25 +14,73 @@ export interface ActionModalProps {
 	onDismiss: () => void;
 	onConfirm: (participant: Participant, type: string) => void;
 	participant: Participant | null;
+	checkInConfirmed: boolean;
 }
 
-function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
+function CheckInModal({
+	onDismiss,
+	onConfirm,
+	participant,
+	checkInConfirmed,
+}: ActionModalProps) {
 	const [selectedType, setSelectedType] = useState("accepted");
+	const [showExitWarning, setShowExitWarning] = useState(false);
+
+	useEffect(() => {
+		setShowExitWarning(false);
+		setSelectedType("accepted");
+	}, [participant]);
 
 	if (!participant) {
 		return null;
 	}
 
+	const handleDismiss = () => {
+		if (!checkInConfirmed) {
+			setShowExitWarning(true);
+		} else {
+			onDismiss();
+		}
+	};
+
+	if (checkInConfirmed) {
+		return (
+			<Modal
+				onDismiss={onDismiss}
+				visible={true}
+				footer={
+					<Box float="right">
+						<Button variant="primary" onClick={onDismiss}>
+							Close
+						</Button>
+					</Box>
+				}
+				header={`Participant Name: ${participant.first_name} ${participant.last_name}`}
+			>
+				<Alert type="success">
+					{participant.first_name} {participant.last_name} has been successfully
+					checked in!
+				</Alert>
+			</Modal>
+		);
+	}
+
 	return (
 		<Modal
-			onDismiss={onDismiss}
+			onDismiss={handleDismiss}
 			visible={true}
 			footer={
 				<Box float="right">
 					<SpaceBetween direction="horizontal" size="xs">
-						<Button variant="link" onClick={onDismiss}>
-							Cancel
-						</Button>
+						{showExitWarning ? (
+							<Button variant="link" onClick={onDismiss}>
+								Exit Anyway
+							</Button>
+						) : (
+							<Button variant="link" onClick={handleDismiss}>
+								Cancel
+							</Button>
+						)}
 						<Button
 							variant="primary"
 							onClick={() => onConfirm(participant, selectedType)}
@@ -41,9 +90,15 @@ function CheckInModal({ onDismiss, onConfirm, participant }: ActionModalProps) {
 					</SpaceBetween>
 				</Box>
 			}
-			header={`Participant Name: ${participant?.first_name} ${participant?.last_name}`}
+			header={`Participant Name: ${participant.first_name} ${participant.last_name}`}
 		>
 			<SpaceBetween size="s">
+				{showExitWarning && (
+					<Alert type="warning">
+						You haven&apos;t checked in this user yet.
+					</Alert>
+				)}
+
 				{selectedType === "accepted" && (
 					<div>
 						<p>


### PR DESCRIPTION
Closes #868 

I know that the issue only targets the warning message for when a user tries to close out without checking out, but I thought doubling down and also giving the successful check in message was helpful in letting users know 100% if they checked in another hacker or not. lmk about this

Check in modal includes 1) check in successful confirmation alert and 2) exit warning.
1) checkInConfirmed boolean state was added so instead of immediately closing the modal on success, triggers success alert with the applicant's name
2) showExitWarning state was added to CheckInModal w/ onDismiss and Cancel handlers. User tries to close modal without completing the check in --> warning alert "You haven't checked in this user yet" + "Exit Anyway" button

Vid of check in flow

https://github.com/user-attachments/assets/85e47e9a-4885-4075-a493-15ca92120e74


note: should i change 'user' to participant or is it tooo specific? also the word is too long. not sure lmk
