### PR TITLE
Feat/autosave application

### DIFF
--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -315,12 +315,15 @@ async def _apply_flow(
         status=Status.PENDING_REVIEW,
     )
 
-    # add applicant to database
+    # add applicant to database and clear any drafts
     try:
-        await mongodb_handler.update_one(
+        await mongodb_handler.raw_update_one(
             Collection.USERS,
             {"_id": user.uid},
-            applicant.model_dump(),
+            {
+                "$set": applicant.model_dump(),
+                "$unset": {"draft_application_data": ""},
+            },
             upsert=True,
         )
     except RuntimeError:

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -42,7 +42,7 @@ log = getLogger(__name__)
 
 router = APIRouter()
 
-DEADLINE = datetime(2027, 2, 14, 8, 1, tzinfo=timezone.utc)
+DEADLINE = datetime(2026, 2, 14, 8, 1, tzinfo=timezone.utc)
 WAITLIST_OPEN_TIME = datetime(2026, 2, 20, 20, 0, tzinfo=timezone.utc)
 WAITLIST_CLOSE_TIME = datetime(2026, 2, 23, 8, 1, tzinfo=timezone.utc)
 

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 from urllib.parse import urlencode
 
 from fastapi import (
@@ -42,7 +42,7 @@ log = getLogger(__name__)
 
 router = APIRouter()
 
-DEADLINE = datetime(2026, 2, 14, 8, 1, tzinfo=timezone.utc)
+DEADLINE = datetime(2027, 2, 14, 8, 1, tzinfo=timezone.utc)
 WAITLIST_OPEN_TIME = datetime(2026, 2, 20, 20, 0, tzinfo=timezone.utc)
 WAITLIST_CLOSE_TIME = datetime(2026, 2, 23, 8, 1, tzinfo=timezone.utc)
 
@@ -342,6 +342,63 @@ async def _apply_flow(
         "Thank you for submitting an application to ZotHacks 2025! Please "
         + "visit https://zothacks.com/portal to see your application status."
     )
+
+
+class DraftApplicationData(BaseModel):
+    application_type: Literal["Hacker", "Mentor", "Volunteer"]
+    fields: dict[str, str]
+
+
+class DraftApplicationResponse(BaseModel):
+    draft_application_data: Union[DraftApplicationData, None] = None
+
+
+@router.get("/application/draft")
+async def get_application_draft(
+    user: Annotated[User, Depends(require_user_identity)],
+) -> DraftApplicationResponse:
+    user_record = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": user.uid}, ["draft_application_data"]
+    )
+
+    if not user_record:
+        return DraftApplicationResponse()
+
+    return DraftApplicationResponse(**user_record)
+
+
+@router.post("/application/draft", status_code=status.HTTP_204_NO_CONTENT)
+async def save_application_draft(
+    user: Annotated[User, Depends(require_user_identity)],
+    draft: DraftApplicationData,
+) -> None:
+    now = datetime.now(timezone.utc)
+
+    if _is_past_deadline(now):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Applications have closed.")
+
+    existing_record = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": user.uid, "roles": {"$exists": True}}, ["roles"]
+    )
+
+    if existing_record and existing_record.get("roles"):
+        log.error(
+            "User %s already has role %s but tried to save a draft.",
+            user,
+            existing_record["roles"],
+        )
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "User already has a role.")
+
+    try:
+        await mongodb_handler.raw_update_one(
+            Collection.USERS,
+            {"_id": user.uid},
+            {"$set": {"draft_application_data": draft.model_dump()}},
+            upsert=True,
+        )
+    except RuntimeError:
+        log.error("Could not save draft for user %s to MongoDB.", user.uid)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 @router.get("/waiver")

--- a/apps/site/src/lib/components/forms/Textfield.tsx
+++ b/apps/site/src/lib/components/forms/Textfield.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import RequiredAsterisk from "./RequiredAsterisk";
 import normalizeWhitespace from "@/lib/utils/normalizeWhitespace";
 import getWordCount from "@/lib/utils/getWordCount";
+import { useDraftContext } from "./shared/DraftContext";
 
 interface TextfieldProps {
 	name: string;
@@ -30,9 +31,17 @@ export default function Textfield({
 	maxCharCount = 1500,
 	textAreaClass = "h-48",
 }: TextfieldProps) {
-	const [value, setValue] = useState("");
+	const draftContext = useDraftContext();
+	const [value, setValue] = useState(
+		() => draftContext?.initialValues[name] ?? "",
+	);
 
 	const wordCount = getWordCount(value);
+
+	const commitValue = (nextValue: string) => {
+		setValue(nextValue);
+		draftContext?.setValue(name, nextValue);
+	};
 
 	const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		let nextValue = e.target.value;
@@ -44,7 +53,7 @@ export default function Textfield({
 
 		// Allow deletion
 		if (nextValue.length < value.length) {
-			setValue(nextValue);
+			commitValue(nextValue);
 			return;
 		}
 
@@ -54,12 +63,12 @@ export default function Textfield({
 
 			if (nextWordCount > maxWordCount) {
 				const truncated = truncateToWordCount(nextValue, maxWordCount);
-				setValue(truncated);
+				commitValue(truncated);
 				return;
 			}
 		}
 
-		setValue(nextValue);
+		commitValue(nextValue);
 	};
 
 	return (

--- a/apps/site/src/lib/components/forms/shared/BaseForm.tsx
+++ b/apps/site/src/lib/components/forms/shared/BaseForm.tsx
@@ -1,14 +1,30 @@
 "use client";
 
-import { FormEvent, PropsWithChildren, useState } from "react";
+import {
+	FormEvent,
+	PropsWithChildren,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
 import Image from "next/image";
 import axios from "axios";
 
 import Button from "@/lib/components/Button/Button";
 
 import hasDeadlinePassed from "@/lib/utils/hasDeadlinePassed";
+import useDraftAutosave from "@/lib/utils/useDraftAutosave";
 
 import cityBackground from "@/assets/backgrounds/alt_illus_moonless.png";
+
+import { DraftContext } from "./DraftContext";
+
+interface DraftResponse {
+	draft_application_data: {
+		application_type: string;
+		fields: Record<string, string>;
+	} | null;
+}
 
 // Ensure this array matches FIELDS_SUPPORTING_OTHER in ApplicationData.py
 const FIELDS_WITH_OTHER = [
@@ -35,6 +51,45 @@ export default function BaseForm({
 }: PropsWithChildren<BaseFormProps>) {
 	const [submitting, setSubmitting] = useState(false);
 	const [sessionExpired, setSessionExpired] = useState(false);
+	const [fields, setFields] = useState<Record<string, string>>({});
+	const [hasUserEdited, setHasUserEdited] = useState(false);
+	const [draftLoaded, setDraftLoaded] = useState(false);
+
+	// Hydrate textareas from any previously saved draft
+	useEffect(() => {
+		axios
+			.get<DraftResponse>("/api/user/application/draft")
+			.then((res) => {
+				const draft = res.data.draft_application_data;
+				if (draft && draft.application_type === applicationType) {
+					setFields(draft.fields);
+				}
+			})
+			.catch((err) => {
+				if (axios.isAxiosError(err) && err.response?.status === 401) {
+					setSessionExpired(true);
+				}
+			})
+			.finally(() => {
+				setDraftLoaded(true);
+			});
+	}, [applicationType]);
+
+	const handleSessionExpired = useCallback(() => {
+		setSessionExpired(true);
+	}, []);
+
+	const setValue = useCallback((name: string, value: string) => {
+		setFields((prev) => ({ ...prev, [name]: value }));
+		setHasUserEdited(true);
+	}, []);
+
+	useDraftAutosave(
+		applicationType,
+		fields,
+		hasUserEdited,
+		handleSessionExpired,
+	);
 
 	const handleSubmit = async (
 		event: FormEvent<HTMLFormElement>,
@@ -135,13 +190,19 @@ export default function BaseForm({
 						readOnly
 						hidden
 					/>
-					{children}
-					<Button
-						text="Submit"
-						className="text-2xl !px-11 !py-2"
-						isLightVersion={true}
-						disabled={submitting}
-					/>
+					<DraftContext.Provider value={{ initialValues: fields, setValue }}>
+						{draftLoaded ? (
+							children
+						) : (
+							<p className="text-[var(--color-white)]">Loading your draft...</p>
+						)}
+						<Button
+							text="Submit"
+							className="text-2xl !px-11 !py-2"
+							isLightVersion={true}
+							disabled={submitting || !draftLoaded}
+						/>
+					</DraftContext.Provider>
 					{sessionExpired && sessionExpiredMessage}
 				</form>
 			</div>

--- a/apps/site/src/lib/components/forms/shared/DraftContext.ts
+++ b/apps/site/src/lib/components/forms/shared/DraftContext.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export interface DraftContextValue {
+	initialValues: Record<string, string>;
+	setValue: (name: string, value: string) => void;
+}
+
+export const DraftContext = createContext<DraftContextValue | null>(null);
+
+export function useDraftContext() {
+	return useContext(DraftContext);
+}

--- a/apps/site/src/lib/utils/hasDeadlinePassed.ts
+++ b/apps/site/src/lib/utils/hasDeadlinePassed.ts
@@ -1,5 +1,5 @@
 export default function hasDeadlinePassed() {
-	const pstDeadline = "2026-02-14T00:00:59";
+	const pstDeadline = "2027-02-14T00:00:59";
 	const utcOffset = "-08:00";
 
 	const deadline = new Date(pstDeadline + utcOffset);

--- a/apps/site/src/lib/utils/hasDeadlinePassed.ts
+++ b/apps/site/src/lib/utils/hasDeadlinePassed.ts
@@ -1,5 +1,5 @@
 export default function hasDeadlinePassed() {
-	const pstDeadline = "2027-02-14T00:00:59";
+	const pstDeadline = "2026-02-14T00:00:59";
 	const utcOffset = "-08:00";
 
 	const deadline = new Date(pstDeadline + utcOffset);

--- a/apps/site/src/lib/utils/useDraftAutosave.ts
+++ b/apps/site/src/lib/utils/useDraftAutosave.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import axios from "axios";
+
+// Prevent excessive API calls by debouncing the autosave
+const DEBOUNCE_MS = 800;
+
+type ApplicationType = "Hacker" | "Mentor" | "Volunteer";
+
+export default function useDraftAutosave(
+	applicationType: ApplicationType,
+	fields: Record<string, string>,
+	hasUserEdited: boolean,
+	onSessionExpired: () => void,
+) {
+	const onSessionExpiredRef = useRef(onSessionExpired);
+
+	useEffect(() => {
+		onSessionExpiredRef.current = onSessionExpired;
+	}, [onSessionExpired]);
+
+	useEffect(() => {
+		if (!hasUserEdited) {
+			return;
+		}
+
+		const timeoutId = setTimeout(() => {
+			axios
+				.post("/api/user/application/draft", {
+					application_type: applicationType,
+					fields,
+				})
+				.catch((err) => {
+					if (axios.isAxiosError(err) && err.response?.status === 401) {
+						onSessionExpiredRef.current();
+					}
+				});
+		}, DEBOUNCE_MS);
+
+		return () => clearTimeout(timeoutId);
+	}, [applicationType, fields, hasUserEdited]);
+}


### PR DESCRIPTION
## Summary:
Autosaves applicant free-response answers to the DB

## New DB Field:
New `draft_application_data` field in the user's collection:
`draft_application_data: { application_type: "Hacker" | "Mentor" | "Volunteer", fields: { frq_change: "...", frq_ambition: "...", frq_character: "..." } }`

Cleared automatically on successful application submission.

## Backend Endpoints:
- `GET /user/application/draft` -- returns the current user's draft (or `null`).
- `POST /user/application/draft` -- upserts the current user's draft.

## Frontend
- `useDraftAutosave` hook: POSTs the form state 800 ms after the last keystroke (arbitrary number, felt like a good sweet spot after testing but can change if needed).
- `DraftContext` + small changes to `Textfield` / `BaseForm`: hydrates textareas on mount and reports edits up for autosave.