### PR TITLE
Fix/notification missing fields

### DIFF
--- a/apps/site/src/app/admin/applicants/components/Applicant.tsx
+++ b/apps/site/src/app/admin/applicants/components/Applicant.tsx
@@ -79,8 +79,16 @@ function Applicant({ uid, applicationType, guidelines }: ApplicantProps) {
 		notes: string | null,
 	) => {
 		submitDetailedReview(Uid, scores, notes).then(() => {
-			if (setNotifications)
+			if (setNotifications) {
 				setNotifications((prev) => [successMessage, ...prev]);
+				setTimeout(
+					() =>
+						setNotifications((prev) =>
+							prev.filter((msg) => msg.id !== successMessage.id),
+						),
+					3000,
+				);
+			}
 			setNotes("");
 		});
 	};

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
@@ -73,17 +73,19 @@ function HackerApplicantActions({
 
 		if (hasMissingFields) {
 			const msgId = `missing-fields-${Date.now()}`;
+			const dismiss = () =>
+				setNotifications?.((prev) => prev.filter((m) => m.id !== msgId));
 			setNotifications?.((prev) => [
 				{
 					type: "error",
 					content: "Missing required fields.",
 					id: msgId,
 					dismissible: true,
-					onDismiss: () =>
-						setNotifications((prev) => prev.filter((m) => m.id !== msgId)),
+					onDismiss: dismiss,
 				} as FlashbarProps.MessageDefinition,
 				...prev,
 			]);
+			setTimeout(dismiss, 3000);
 			return;
 		}
 

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
@@ -2,10 +2,12 @@ import { useContext } from "react";
 
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
+import { FlashbarProps } from "@cloudscape-design/components/flashbar";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 
 import { Review } from "@/lib/admin/useApplicant";
 import { Uid } from "@/lib/userRecord";
+import NotificationContext from "@/lib/admin/NotificationContext";
 import UserContext from "@/lib/admin/UserContext";
 import { isReviewer } from "@/lib/admin/authorization";
 import {
@@ -46,6 +48,7 @@ function HackerApplicantActions({
 	onSubmitDetailedReview,
 }: ApplicantActionsProps) {
 	const { uid, roles } = useContext(UserContext);
+	const { setNotifications } = useContext(NotificationContext);
 
 	const uniqueReviewers = Array.from(
 		new Set(reviews.map((review) => review[1])),
@@ -61,7 +64,29 @@ function HackerApplicantActions({
 	}
 
 	const handleClick = () => {
-		// TODO: use flashbar or modal for submit status
+		const hasMissingFields = [
+			"previous_experience",
+			"frq_change",
+			"frq_ambition",
+			"frq_character",
+		].some((field) => !(field in scores));
+
+		if (hasMissingFields) {
+			const msgId = `missing-fields-${Date.now()}`;
+			setNotifications?.((prev) => [
+				{
+					type: "error",
+					content: "Missing required fields.",
+					id: msgId,
+					dismissible: true,
+					onDismiss: () =>
+						setNotifications((prev) => prev.filter((m) => m.id !== msgId)),
+				} as FlashbarProps.MessageDefinition,
+				...prev,
+			]);
+			return;
+		}
+
 		onSubmitDetailedReview(applicant, scores, notes ?? null);
 	};
 


### PR DESCRIPTION
When reviewing applications, if a reviewer tries to submit without filling in all required fields (previous experience, and the three FRQ scores), an error notification banner appears and auto-dismisses after 3 seconds. The success notification on a successful review submission also auto-dismisses after 3 seconds. 

Closes #804 