### PR TITLE
Feat/view applicant portal

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -50,6 +50,15 @@ require_hacker_reviewer = require_role({Role.DIRECTOR, Role.HACKER_REVIEWER})
 require_mentor_reviewer = require_role({Role.DIRECTOR, Role.MENTOR_REVIEWER})
 require_volunteer_reviewer = require_role({Role.DIRECTOR, Role.VOLUNTEER_REVIEWER})
 require_checkin_lead = require_role({Role.DIRECTOR, Role.CHECKIN_LEAD})
+require_hacker_portal_viewer = require_role(
+    {Role.DIRECTOR, Role.LEAD, Role.CHECKIN_LEAD, Role.HACKER_REVIEWER}
+)
+require_mentor_portal_viewer = require_role(
+    {Role.DIRECTOR, Role.LEAD, Role.CHECKIN_LEAD, Role.MENTOR_REVIEWER}
+)
+require_volunteer_portal_viewer = require_role(
+    {Role.DIRECTOR, Role.LEAD, Role.CHECKIN_LEAD, Role.VOLUNTEER_REVIEWER}
+)
 require_organizer = require_role({Role.ORGANIZER})
 
 
@@ -269,7 +278,9 @@ async def applicant(
         raise RuntimeError("Could not parse applicant data.")
 
 
-@router.get("/applicant/hacker/{uid}", dependencies=[Depends(require_hacker_reviewer)])
+@router.get(
+    "/applicant/hacker/{uid}", dependencies=[Depends(require_hacker_portal_viewer)]
+)
 async def hacker_applicant(
     uid: str,
 ) -> Applicant:
@@ -277,7 +288,9 @@ async def hacker_applicant(
     return await applicant(uid, "Hacker")
 
 
-@router.get("/applicant/mentor/{uid}", dependencies=[Depends(require_mentor_reviewer)])
+@router.get(
+    "/applicant/mentor/{uid}", dependencies=[Depends(require_mentor_portal_viewer)]
+)
 async def mentor_applicant(
     uid: str,
 ) -> Applicant:
@@ -286,7 +299,8 @@ async def mentor_applicant(
 
 
 @router.get(
-    "/applicant/volunteer/{uid}", dependencies=[Depends(require_volunteer_reviewer)]
+    "/applicant/volunteer/{uid}",
+    dependencies=[Depends(require_volunteer_portal_viewer)],
 )
 async def volunteer_applicant(
     uid: str,

--- a/apps/site/src/app/(main)/portal-preview/[type]/[uid]/page.tsx
+++ b/apps/site/src/app/(main)/portal-preview/[type]/[uid]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound, redirect } from "next/navigation";
+
+import { canViewPortalPreview } from "@/lib/admin/authorization";
+import getUserIdentity from "@/lib/utils/getUserIdentity";
+
+import PortalPreviewClient from "../../components/PortalPreviewClient";
+
+const VALID_TYPES = ["hacker", "mentor", "volunteer"] as const;
+type ApplicationType = (typeof VALID_TYPES)[number];
+
+interface PageProps {
+	params: { type: string; uid: string };
+}
+
+async function PortalPreviewPage({ params }: PageProps) {
+	const { type, uid } = params;
+
+	if (!VALID_TYPES.includes(type as ApplicationType)) {
+		notFound();
+	}
+
+	const { uid: viewerUid, roles } = await getUserIdentity();
+
+	if (viewerUid === null) {
+		redirect("/login");
+	}
+
+	if (!canViewPortalPreview(roles)) {
+		redirect("/unauthorized");
+	}
+
+	return (
+		<PortalPreviewClient uid={uid} applicationType={type as ApplicationType} />
+	);
+}
+
+export default PortalPreviewPage;

--- a/apps/site/src/app/(main)/portal-preview/components/PortalPreviewClient.tsx
+++ b/apps/site/src/app/(main)/portal-preview/components/PortalPreviewClient.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import ApplicantPortal from "@/app/(main)/portal/@applicant/ApplicantPortal";
+import useApplicant from "@/lib/admin/useApplicant";
+import { ApplicationData } from "@/lib/utils/useApplicationData";
+import { Identity } from "@/lib/utils/useUserIdentity";
+
+interface PortalPreviewClientProps {
+	uid: string;
+	applicationType: "hacker" | "mentor" | "volunteer";
+}
+
+function PortalPreviewClient({
+	uid,
+	applicationType,
+}: PortalPreviewClientProps) {
+	const { applicant, loading, error } = useApplicant(uid, applicationType);
+
+	if (error) {
+		return (
+			<div className="font-display text-2xl mt-5 text-[var(--color-white)]">
+				Unable to load applicant.
+			</div>
+		);
+	}
+
+	if (loading || !applicant) {
+		return <div className="font-display text-4xl mt-5">Loading...</div>;
+	}
+
+	const identity: Identity = {
+		uid: applicant._id,
+		roles: applicant.roles,
+		status: applicant.status,
+		decision: applicant.decision,
+	};
+
+	const applicationData: ApplicationData = {
+		application_data:
+			"character_head_index" in applicant.application_data
+				? {
+						character_head_index:
+							applicant.application_data.character_head_index,
+						character_body_index:
+							applicant.application_data.character_body_index,
+						character_feet_index:
+							applicant.application_data.character_feet_index,
+						character_companion_index:
+							applicant.application_data.character_companion_index,
+				  }
+				: null,
+	};
+
+	return (
+		<ApplicantPortal
+			identity={identity}
+			applicationData={applicationData}
+			readOnly
+		/>
+	);
+}
+
+export default PortalPreviewClient;

--- a/apps/site/src/app/(main)/portal-preview/layout.tsx
+++ b/apps/site/src/app/(main)/portal-preview/layout.tsx
@@ -1,0 +1,25 @@
+import { PropsWithChildren } from "react";
+
+import heroFried from "@/assets/backgrounds/hero-fried.png";
+
+function PortalPreviewLayout({ children }: PropsWithChildren) {
+	return (
+		<section
+			className="w-full flex items-center flex-col min-h-screen bg-cover bg-center bg-no-repeat relative"
+			style={{ backgroundImage: `url(${heroFried.src})` }}
+		>
+			<div className="absolute inset-0 backdrop-blur-[4px]" />
+			<div className="relative z-10 mt-20 md:mt-36 md:mb-10">
+				<h1
+					className="font-display font-bold text-3xl sm:text-5xl md:text-7xl text-center text-[var(--color-yellow)]"
+					style={{ textShadow: "0px 0px 25px rgba(229, 242, 0, 1)" }}
+				>
+					Portal Preview
+				</h1>
+			</div>
+			<div className="relative z-10">{children}</div>
+		</section>
+	);
+}
+
+export default PortalPreviewLayout;

--- a/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/ApplicantPortal.tsx
@@ -2,7 +2,8 @@
 
 import { redirect } from "next/navigation";
 
-import useUserIdentity from "@/lib/utils/useUserIdentity";
+import useUserIdentity, { Identity } from "@/lib/utils/useUserIdentity";
+import { ApplicationData } from "@/lib/utils/useApplicationData";
 import { Decision, Status } from "@/lib/userRecord";
 import useWaitlistOpen from "@/lib/utils/useWaitlistOpen";
 
@@ -16,8 +17,19 @@ import AvatarDisplay from "./components/AvatarDisplay";
 
 const rolesArray = ["Mentor", "Hacker", "Volunteer"];
 
-function Portal() {
-	const identity = useUserIdentity();
+interface PortalProps {
+	identity?: Identity;
+	applicationData?: ApplicationData;
+	readOnly?: boolean;
+}
+
+function Portal({
+	identity: identityProp,
+	applicationData,
+	readOnly = false,
+}: PortalProps = {}) {
+	const hookIdentity = useUserIdentity();
+	const identity = identityProp ?? hookIdentity;
 	const { waitlistStatus, isLoading: isWaitlistLoading } = useWaitlistOpen();
 
 	if (!identity || isWaitlistLoading) {
@@ -26,7 +38,7 @@ function Portal() {
 
 	const status = identity.status;
 
-	if (status === null) {
+	if (status === null && identityProp === undefined) {
 		redirect("/#apply");
 	}
 
@@ -50,8 +62,17 @@ function Portal() {
 	return (
 		<div className="relative">
 			<div className="bg-transparent text-black max-w-6xl rounded-2xl p-6 flex flex-col mb-24 w-full">
+				{readOnly && (
+					<div className="bg-yellow-500/20 border-2 border-yellow-400 rounded-lg p-4 mb-6 text-yellow-200 text-center font-display">
+						Preview mode — actions are disabled
+					</div>
+				)}
 				<div className="mb-12">
-					<QRCodeComponent className="max-w-xs mx-auto" size={180} />
+					<QRCodeComponent
+						uid={identity.uid ?? undefined}
+						className="max-w-xs mx-auto"
+						size={180}
+					/>
 					<p className="mt-4 text-white text-center">
 						If selected to attend, please show this QR code to our staff to
 						check-in.
@@ -61,7 +82,7 @@ function Portal() {
 				<h2 className="font-bold font-display text-[var(--color-white)] mb-4 md:mb-[42px] text-[15px] sm:text-2xl md:text-[40px] md:leading-10">
 					{roleToDisplay} Application Status
 				</h2>
-				<AvatarDisplay />
+				<AvatarDisplay applicationData={applicationData} />
 				<VerticalTimeline
 					status={identity?.decision ? identity?.decision : (status as Status)}
 				/>
@@ -74,9 +95,12 @@ function Portal() {
 						status={status as Status}
 						decision={identity?.decision as Decision}
 						waitlistOpen={waitlistOpen}
+						readOnly={readOnly}
 					/>
 				)}
-				{needsToRSVP && <ConfirmAttendance status={status as Status} />}
+				{needsToRSVP && (
+					<ConfirmAttendance status={status as Status} readOnly={readOnly} />
+				)}
 				{rejected && <ReturnHome />}
 			</div>
 		</div>

--- a/apps/site/src/app/(main)/portal/@applicant/components/AvatarDisplay.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/AvatarDisplay.tsx
@@ -34,7 +34,9 @@ import companion4 from "@/assets/images/characterCustomizer/companion_4.png";
 import blankBody from "@/assets/images/characterCustomizer/blank_body.png";
 import blankHead from "@/assets/images/characterCustomizer/blank_head.png";
 import blankTail from "@/assets/images/characterCustomizer/blank_tail.png";
-import useApplicationData from "@/lib/utils/useApplicationData";
+import useApplicationData, {
+	ApplicationData,
+} from "@/lib/utils/useApplicationData";
 
 const HEADS: [StaticImageData, string][] = [
 	[head1, "Kitty Headphones"],
@@ -64,8 +66,13 @@ const COMPANIONS: [StaticImageData, string][] = [
 
 const imageWidth = 600;
 
-export const AvatarDisplay = () => {
-	const data = useApplicationData();
+interface AvatarDisplayProps {
+	applicationData?: ApplicationData;
+}
+
+export const AvatarDisplay = ({ applicationData }: AvatarDisplayProps = {}) => {
+	const hookData = useApplicationData();
+	const data = applicationData ?? hookData;
 
 	return (
 		<div className="relative w-full border-white border-4 rounded-xl bg-gradient-to-b from-[#02031D] via-[#090D83] via-54% to-[#090D83] mb-10">

--- a/apps/site/src/app/(main)/portal/@applicant/components/ConfirmAttendance.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/ConfirmAttendance.tsx
@@ -4,9 +4,13 @@ import RsvpForm from "./RsvpForm";
 
 interface ConfirmAttendanceProps {
 	status: Status;
+	readOnly?: boolean;
 }
 
-function ConfirmAttendance({ status }: ConfirmAttendanceProps) {
+function ConfirmAttendance({
+	status,
+	readOnly = false,
+}: ConfirmAttendanceProps) {
 	const buttonText =
 		status === Status.Confirmed || status === Status.Attending
 			? "I am no longer able to attend IrvineHacks 2026"
@@ -33,7 +37,9 @@ function ConfirmAttendance({ status }: ConfirmAttendanceProps) {
 							<span className="underline">NOT</span> be able to RSVP again.
 						</strong>
 					)}
-					{status === Status.Confirmed && <LateArrivalForm />}
+					{status === Status.Confirmed && (
+						<LateArrivalForm readOnly={readOnly} />
+					)}
 				</>
 			) : (
 				<>
@@ -56,7 +62,11 @@ function ConfirmAttendance({ status }: ConfirmAttendanceProps) {
 			)}
 			{status !== Status.Confirmed && status !== Status.Attending && (
 				<div className="mt-2 md:mt-8">
-					<RsvpForm buttonText={buttonText} showWarning={false} />
+					<RsvpForm
+						buttonText={buttonText}
+						showWarning={false}
+						readOnly={readOnly}
+					/>
 				</div>
 			)}
 		</div>

--- a/apps/site/src/app/(main)/portal/@applicant/components/LateArrivalForm.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/LateArrivalForm.tsx
@@ -12,7 +12,13 @@ const ARRIVAL_TIMES = [
 	{ value: "19:30", text: "7:30 PM" },
 ];
 
-export default function LateArrivalForm() {
+interface LateArrivalFormProps {
+	readOnly?: boolean;
+}
+
+export default function LateArrivalForm({
+	readOnly = false,
+}: LateArrivalFormProps = {}) {
 	const [arrivalTime, setArrivalTime] = useState<string>("18:00");
 	const arrivalData = useArrivalTime();
 	const currentArrivalTimeLabel = ARRIVAL_TIMES.find(
@@ -53,6 +59,11 @@ export default function LateArrivalForm() {
 				<form
 					method="post"
 					action="/api/user/rsvp/late-arrival"
+					onSubmit={(event) => {
+						if (readOnly) {
+							event.preventDefault();
+						}
+					}}
 					className="space-y-4"
 				>
 					<ControlledDropdownSelect
@@ -69,6 +80,7 @@ export default function LateArrivalForm() {
 						<Button
 							text="Save arrival time"
 							isLightVersion={true}
+							disabled={readOnly}
 							className="text-xs sm:text-base md:text-4xl !bg-pink"
 						/>
 					</div>

--- a/apps/site/src/app/(main)/portal/@applicant/components/QRCode.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/QRCode.tsx
@@ -2,17 +2,20 @@ import useUserIdentity from "@/lib/utils/useUserIdentity";
 import QRCode from "react-qr-code";
 
 interface QRCodeComponentProps {
+	uid?: string;
 	className?: string;
 	size?: number;
 }
 
 export default function QRCodeComponent({
+	uid: uidProp,
 	className = "",
 	size = 200,
 }: QRCodeComponentProps) {
 	const identity = useUserIdentity();
+	const uid = uidProp ?? identity?.uid;
 
-	if (!identity) {
+	if (uid === undefined) {
 		return (
 			<div className={`text-center p-4 ${className}`}>
 				<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
@@ -30,7 +33,7 @@ export default function QRCodeComponent({
 			<div className="mb-4 flex justify-center">
 				<QRCode
 					id="qr-code-svg"
-					value={identity.uid ?? ""}
+					value={uid ?? ""}
 					size={size}
 					style={{ height: "auto", maxWidth: "100%", width: "100%" }}
 					viewBox={`0 0 ${size} ${size}`}

--- a/apps/site/src/app/(main)/portal/@applicant/components/RsvpForm.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/RsvpForm.tsx
@@ -7,6 +7,7 @@ import ControlledDropdownSelect from "@/lib/components/forms/ControlledDropdownS
 interface RsvpFormProps {
 	buttonText: string;
 	showWarning: boolean;
+	readOnly?: boolean;
 }
 
 // Only late options, 6:00 PM is default from first dropdown
@@ -17,7 +18,11 @@ const LATE_ARRIVAL_TIME_OPTIONS = [
 	{ value: "19:30", label: "7:30 PM" },
 ] as const;
 
-export default function RsvpForm({ buttonText, showWarning }: RsvpFormProps) {
+export default function RsvpForm({
+	buttonText,
+	showWarning,
+	readOnly = false,
+}: RsvpFormProps) {
 	const [comingLateChoice, setComingLateChoice] = useState<"" | "no" | "yes">(
 		"",
 	);
@@ -32,6 +37,10 @@ export default function RsvpForm({ buttonText, showWarning }: RsvpFormProps) {
 			method="post"
 			action="/api/user/rsvp"
 			onSubmit={(event) => {
+				if (readOnly) {
+					event.preventDefault();
+					return;
+				}
 				if (showWarning && !confirm(confirmationMessage)) {
 					event.preventDefault();
 				}
@@ -77,6 +86,7 @@ export default function RsvpForm({ buttonText, showWarning }: RsvpFormProps) {
 				<Button
 					text={buttonText}
 					isLightVersion={true}
+					disabled={readOnly}
 					className="text-xs sm:text-base md:text-4xl !bg-pink"
 				/>
 			</div>

--- a/apps/site/src/app/(main)/portal/@applicant/components/SignWaiver.tsx
+++ b/apps/site/src/app/(main)/portal/@applicant/components/SignWaiver.tsx
@@ -5,9 +5,15 @@ interface SignWaiverProps {
 	status: Status;
 	decision: Decision;
 	waitlistOpen: boolean;
+	readOnly?: boolean;
 }
 
-function SignWaiver({ status, decision, waitlistOpen }: SignWaiverProps) {
+function SignWaiver({
+	status,
+	decision,
+	waitlistOpen,
+	readOnly = false,
+}: SignWaiverProps) {
 	return (
 		<div className="mt-4 md:mt-10 text-[var(--color-white)]">
 			<h3 className="font-bold font-display mb-[9px] md:mb-[20px] text-[0.9375rem] sm:text-2xl md:text-[2.5rem] md:leading-10">
@@ -26,14 +32,23 @@ function SignWaiver({ status, decision, waitlistOpen }: SignWaiverProps) {
 				)}
 			</p>
 			<div className="mt-6 md:mt-12">
-				<Button
-					text="Sign Waiver to attend IrvineHacks 2026"
-					href="https://app.hellosign.com/s/1C2DkqYe"
-					newWindow={true}
-					usePrefetch={false}
-					isLightVersion={true}
-					className="!bg-pink !w-full md:!w-[875px] !font-sans !font-medium md:text-3xl !leading-none !tracking-normal !text-center"
-				/>
+				{readOnly ? (
+					<Button
+						text="Sign Waiver to attend IrvineHacks 2026"
+						isLightVersion={true}
+						disabled={true}
+						className="!bg-pink !w-full md:!w-[875px] !font-sans !font-medium md:text-3xl !leading-none !tracking-normal !text-center"
+					/>
+				) : (
+					<Button
+						text="Sign Waiver to attend IrvineHacks 2026"
+						href="https://app.hellosign.com/s/1C2DkqYe"
+						newWindow={true}
+						usePrefetch={false}
+						isLightVersion={true}
+						className="!bg-pink !w-full md:!w-[875px] !font-sans !font-medium md:text-3xl !leading-none !tracking-normal !text-center"
+					/>
+				)}
 			</div>
 			<p className="text-xl w-full text-center mt-2 text-yellow-500">
 				If you have signed the waiver and received a confirmation, you do not

--- a/apps/site/src/app/admin/applicants/components/Applicant.tsx
+++ b/apps/site/src/app/admin/applicants/components/Applicant.tsx
@@ -1,12 +1,15 @@
 "use client";
 import { useState, useContext } from "react";
+import Button from "@cloudscape-design/components/button";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import { FlashbarProps } from "@cloudscape-design/components/flashbar";
 
+import { canViewPortalPreview } from "@/lib/admin/authorization";
 import NotificationContext from "@/lib/admin/NotificationContext";
+import UserContext from "@/lib/admin/UserContext";
 import useApplicant, {
 	IrvineHacksHackerApplicationData,
 	IrvineHacksMentorApplicationData,
@@ -40,6 +43,9 @@ interface ApplicantProps {
 
 function Applicant({ uid, applicationType, guidelines }: ApplicantProps) {
 	const { setNotifications } = useContext(NotificationContext);
+	const { roles: viewerRoles } = useContext(UserContext);
+	const previewHref = `/portal-preview/${applicationType}/${uid}`;
+	const showPortalPreviewLink = canViewPortalPreview(viewerRoles);
 	const {
 		applicant,
 		loading,
@@ -94,6 +100,11 @@ function Applicant({ uid, applicationType, guidelines }: ApplicantProps) {
 					actions={
 						applicant.roles.includes(ParticipantRole.Hacker) ? (
 							<SpaceBetween direction="horizontal" size="xs">
+								{showPortalPreviewLink && (
+									<Button href={previewHref} target="_blank" external>
+										View as applicant
+									</Button>
+								)}
 								<ApplicantNavigationButtons
 									uid={uid}
 									basePath="/admin/applicants/hackers" // hardcoded for Irvinehacks (Applicant.tsx)
@@ -107,10 +118,17 @@ function Applicant({ uid, applicationType, guidelines }: ApplicantProps) {
 								/>
 							</SpaceBetween>
 						) : (
-							<ApplicantActions
-								applicant={applicant._id}
-								submitReview={submitReview}
-							/>
+							<SpaceBetween direction="horizontal" size="xs">
+								{showPortalPreviewLink && (
+									<Button href={previewHref} target="_blank" external>
+										View as applicant
+									</Button>
+								)}
+								<ApplicantActions
+									applicant={applicant._id}
+									submitReview={submitReview}
+								/>
+							</SpaceBetween>
 						)
 					}
 				>

--- a/apps/site/src/lib/admin/authorization.ts
+++ b/apps/site/src/lib/admin/authorization.ts
@@ -42,6 +42,12 @@ export function isLead(roles: ReadonlyArray<Role>): boolean {
 	return roles.includes(AdminRole.Lead);
 }
 
+export function canViewPortalPreview(roles: ReadonlyArray<Role>): boolean {
+	return (
+		isDirector(roles) || isLead(roles) || roles.includes(AdminRole.CheckInLead)
+	);
+}
+
 export function isHackerReviewer(roles: ReadonlyArray<Role>): boolean {
 	return (
 		roles.includes(AdminRole.Director) ||

--- a/apps/site/src/lib/admin/useApplicant.ts
+++ b/apps/site/src/lib/admin/useApplicant.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
 import useSWR from "swr";
 
-import { ParticipantRole, Status, Uid, Score } from "@/lib/userRecord";
+import {
+	Decision,
+	ParticipantRole,
+	Status,
+	Uid,
+	Score,
+} from "@/lib/userRecord";
 
 export type Review = [string, Uid, Score, string | null];
 
@@ -167,6 +173,7 @@ export interface Applicant {
 	last_name: string;
 	roles: ReadonlyArray<ParticipantRole>;
 	status: Status;
+	decision?: Decision;
 	application_data: ApplicationData;
 }
 


### PR DESCRIPTION
**Summary**
Lets Directors, Leads, and Check-in Leads open a read-only preview of what a specific hacker/mentor/volunteer sees on the applicant portal.

**New Routes**
- `/portal-preview/hacker/[uid]` -- Preview hacker’s portal UI
- `/portal-preview/mentor/[uid]` -- Preview mentor’s portal UI
- `/portal-preview/volunteer/[uid]` -- Preview volunteer’s portal UI

**How to View**
Visit `portal-preview/[type]/[uid]` or go to the Admin Dashboard with an account that has role "Director," "Check-in Lead," or "Lead" and then click an application and click "View as Applicant" button.