### PR TITLE
feat: session timeout modal

### DIFF
--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -10,6 +10,7 @@ from fastapi import (
     Header,
     HTTPException,
     Request,
+    Response,
     status,
 )
 from fastapi.datastructures import URL, FormData
@@ -126,6 +127,13 @@ async def logout() -> RedirectResponse:
     user_identity.remove_user_identity(response)
     return response
 
+@router.post("/refresh")
+async def refresh_token(
+    user: Annotated[User, Depends(require_user_identity)],
+    response: Response,
+) -> None:
+    """Issue a new token for the user, extending their session by 1 hour."""
+    user_identity.issue_user_identity(user, response)
 
 @router.get("/me")
 async def me(

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -127,6 +127,7 @@ async def logout() -> RedirectResponse:
     user_identity.remove_user_identity(response)
     return response
 
+
 @router.post("/refresh")
 async def refresh_token(
     user: Annotated[User, Depends(require_user_identity)],
@@ -134,6 +135,7 @@ async def refresh_token(
 ) -> None:
     """Issue a new token for the user, extending their session by 1 hour."""
     user_identity.issue_user_identity(user, response)
+
 
 @router.get("/me")
 async def me(

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -28,13 +28,10 @@ function AdminLayout({ children }: PropsWithChildren) {
 	const [notifications, setNotifications] = useState<
 		FlashbarProps.MessageDefinition[]
 	>([]);
-	
 	const [showTimeoutModal, setShowTimeoutModal] = useState(false);
-	
 	const handleWarning = useCallback(() => {
 		setShowTimeoutModal(true);
 	}, []);
-	
 	const handleExpired = useCallback(() => {
 		setShowTimeoutModal(false);
 	}, []);
@@ -52,7 +49,7 @@ function AdminLayout({ children }: PropsWithChildren) {
 	const handleLogout = useCallback(() => {
 		setShowTimeoutModal(false);
 		logout();
-	}, [logout]); 
+	}, [logout]);
 
 	useEffect(() => {
 		setNotifications(() => []);

--- a/apps/site/src/app/admin/layout/AdminLayout.tsx
+++ b/apps/site/src/app/admin/layout/AdminLayout.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, usePathname } from "next/navigation";
 
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useCallback, useEffect, useState } from "react";
 
 import AppLayout from "@cloudscape-design/components/app-layout";
 import Flashbar, {
@@ -18,6 +18,8 @@ import useUserIdentityStatic from "@/lib/admin/useUserIdentityStatic";
 
 import AdminSidebar from "./AdminSidebar";
 import Breadcrumbs from "./Breadcrumbs";
+import SessionTimeoutModal from "./SessionTimeoutModal";
+import { useSessionTimeout } from "@/lib/admin/useSessionTimeout";
 
 function AdminLayout({ children }: PropsWithChildren) {
 	const identity = useUserIdentityStatic();
@@ -26,6 +28,31 @@ function AdminLayout({ children }: PropsWithChildren) {
 	const [notifications, setNotifications] = useState<
 		FlashbarProps.MessageDefinition[]
 	>([]);
+	
+	const [showTimeoutModal, setShowTimeoutModal] = useState(false);
+	
+	const handleWarning = useCallback(() => {
+		setShowTimeoutModal(true);
+	}, []);
+	
+	const handleExpired = useCallback(() => {
+		setShowTimeoutModal(false);
+	}, []);
+
+	const { logout, extendSession } = useSessionTimeout({
+		onWarning: handleWarning,
+		onExpired: handleExpired,
+	});
+
+	const handleExtend = useCallback(async () => {
+		setShowTimeoutModal(false);
+		await extendSession();
+	}, [extendSession]);
+
+	const handleLogout = useCallback(() => {
+		setShowTimeoutModal(false);
+		logout();
+	}, [logout]); 
 
 	useEffect(() => {
 		setNotifications(() => []);
@@ -92,6 +119,11 @@ function AdminLayout({ children }: PropsWithChildren) {
 								inProgressIconAriaLabel: "In progress",
 							}}
 							stackItems
+						/>
+						<SessionTimeoutModal
+							visible={showTimeoutModal}
+							onExtend={handleExtend}
+							onLogout={handleLogout}
 						/>
 					</div>
 				</NotificationContext.Provider>

--- a/apps/site/src/app/admin/layout/SessionTimeoutModal.tsx
+++ b/apps/site/src/app/admin/layout/SessionTimeoutModal.tsx
@@ -83,7 +83,12 @@ function SessionTimeoutModal({
 				>
 					{formattedTime}
 				</Box>
-				<Box variant="p" textAlign="center" color="text-body-secondary" fontSize="body-s">
+				<Box
+					variant="p"
+					textAlign="center"
+					color="text-body-secondary"
+					fontSize="body-s"
+				>
 					Would you like to keep working?
 				</Box>
 			</SpaceBetween>

--- a/apps/site/src/app/admin/layout/SessionTimeoutModal.tsx
+++ b/apps/site/src/app/admin/layout/SessionTimeoutModal.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+interface SessionTimeoutModalProps {
+	visible: boolean;
+	onExtend: () => void;
+	onLogout: () => void;
+}
+
+const WARNING_SECONDS = 2 * 60; // 2 minutes
+
+function SessionTimeoutModal({
+	visible,
+	onExtend,
+	onLogout,
+}: SessionTimeoutModalProps) {
+	const [secondsLeft, setSecondsLeft] = useState(WARNING_SECONDS);
+
+	// Reset and start countdown whenever modal becomes visible
+	useEffect(() => {
+		if (!visible) {
+			setSecondsLeft(WARNING_SECONDS);
+			return;
+		}
+
+		setSecondsLeft(WARNING_SECONDS);
+		// Countdown logic
+		const interval = setInterval(() => {
+			setSecondsLeft((prev) => {
+				if (prev <= 1) {
+					clearInterval(interval);
+					return 0;
+				}
+				return prev - 1;
+			});
+		}, 1000);
+
+		return () => clearInterval(interval);
+	}, [visible]);
+
+	const minutes = Math.floor(secondsLeft / 60);
+	const seconds = secondsLeft % 60;
+	const formattedTime = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+	const isUrgent = secondsLeft <= 30;
+
+	return (
+		<Modal
+			visible={visible}
+			onDismiss={onExtend}
+			closeAriaLabel="Close"
+			footer={
+				<div className="flex justify-center">
+					<SpaceBetween direction="horizontal" size="xs">
+						<Button variant="normal" onClick={onLogout}>
+							Logout now
+						</Button>
+						<Button variant="primary" onClick={onExtend}>
+							Keep working
+						</Button>
+					</SpaceBetween>
+				</div>
+			}
+		>
+			<SpaceBetween size="m">
+				<Box variant="h1" textAlign="center">
+					Session will expire soon!
+				</Box>
+				<Box variant="p" textAlign="center">
+					You will be automatically logged out for security reasons in:
+				</Box>
+				<Box
+					variant="p"
+					textAlign="center"
+					fontSize="display-l"
+					fontWeight="bold"
+					color={isUrgent ? "text-status-error" : "inherit"}
+				>
+					{formattedTime}
+				</Box>
+				<Box variant="p" textAlign="center" color="text-body-secondary" fontSize="body-s">
+					Would you like to keep working?
+				</Box>
+			</SpaceBetween>
+		</Modal>
+	);
+}
+
+export default SessionTimeoutModal;

--- a/apps/site/src/lib/admin/useSessionTimeout.ts
+++ b/apps/site/src/lib/admin/useSessionTimeout.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+
+const SESSION_DURATION = 60 * 60 * 1000; // Based on JWT token expiration (1 hour)
+const WARNING_TIME = 2 * 60 * 1000; // Warn 2 minutes before expiration
+const STORAGE_KEY = "irvinehacks_session_start"; // For localStorage
+
+interface UseSessionTimeoutOptions {
+	onWarning: () => void;
+	onExpired: () => void;
+}
+
+export function useSessionTimeout({ onWarning, onExpired }: UseSessionTimeoutOptions) {
+	const router = useRouter();
+	const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const expirationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const clearTimers = useCallback(() => {
+		if (warningTimerRef.current) {
+			clearTimeout(warningTimerRef.current);
+		}
+		if (expirationTimerRef.current) {
+			clearTimeout(expirationTimerRef.current);
+		}
+	}, []);
+
+	const logout = useCallback(() => {
+		clearTimers();
+		localStorage.removeItem(STORAGE_KEY);
+		router.push("/logout");
+	}, [clearTimers, router]);
+
+	const scheduleTimers = useCallback(
+		(remainingTime: number) => {
+			clearTimers();
+			if (remainingTime <= WARNING_TIME) {
+				onWarning();
+				expirationTimerRef.current = setTimeout(() => {
+					onExpired();
+					logout();
+				}, remainingTime);
+				return;
+			}
+			warningTimerRef.current = setTimeout(() => {
+				onWarning();
+				expirationTimerRef.current = setTimeout(() => {
+					onExpired();
+					logout();
+				}, WARNING_TIME);
+			}, remainingTime - WARNING_TIME);
+		}, [clearTimers, logout, onExpired, onWarning])
+
+	const extendSession = useCallback(async () => {
+		try {
+			await axios.post("/api/user/refresh");
+			localStorage.setItem(STORAGE_KEY, Date.now().toString());
+			scheduleTimers(SESSION_DURATION);
+		} catch (err) {
+			console.error("Failed to extend session:", err);
+			logout();
+		}
+	}, [logout, scheduleTimers]);
+
+	useEffect(() => {
+		if (!localStorage.getItem(STORAGE_KEY)) {
+			localStorage.setItem(STORAGE_KEY, Date.now().toString());
+		}
+		const sessionStart = parseInt(localStorage.getItem(STORAGE_KEY) ?? Date.now.toString(), 10);
+		const elapsed = Date.now() - sessionStart;
+		const remaining = SESSION_DURATION - elapsed;
+		if (remaining <= 0){
+			onExpired();
+			logout();
+			return;
+		}
+		scheduleTimers(remaining);
+		return clearTimers;
+	}, [clearTimers, logout, onExpired, scheduleTimers]);
+	
+	return { logout, extendSession };
+
+}

--- a/apps/site/src/lib/admin/useSessionTimeout.ts
+++ b/apps/site/src/lib/admin/useSessionTimeout.ts
@@ -11,7 +11,10 @@ interface UseSessionTimeoutOptions {
 	onExpired: () => void;
 }
 
-export function useSessionTimeout({ onWarning, onExpired }: UseSessionTimeoutOptions) {
+export function useSessionTimeout({
+	onWarning,
+	onExpired,
+}: UseSessionTimeoutOptions) {
 	const router = useRouter();
 	const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const expirationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -48,7 +51,9 @@ export function useSessionTimeout({ onWarning, onExpired }: UseSessionTimeoutOpt
 					logout();
 				}, WARNING_TIME);
 			}, remainingTime - WARNING_TIME);
-		}, [clearTimers, logout, onExpired, onWarning])
+		},
+		[clearTimers, logout, onExpired, onWarning],
+	);
 
 	const extendSession = useCallback(async () => {
 		try {
@@ -65,10 +70,13 @@ export function useSessionTimeout({ onWarning, onExpired }: UseSessionTimeoutOpt
 		if (!localStorage.getItem(STORAGE_KEY)) {
 			localStorage.setItem(STORAGE_KEY, Date.now().toString());
 		}
-		const sessionStart = parseInt(localStorage.getItem(STORAGE_KEY) ?? Date.now.toString(), 10);
+		const sessionStart = parseInt(
+			localStorage.getItem(STORAGE_KEY) ?? Date.now.toString(),
+			10,
+		);
 		const elapsed = Date.now() - sessionStart;
 		const remaining = SESSION_DURATION - elapsed;
-		if (remaining <= 0){
+		if (remaining <= 0) {
 			onExpired();
 			logout();
 			return;
@@ -76,7 +84,6 @@ export function useSessionTimeout({ onWarning, onExpired }: UseSessionTimeoutOpt
 		scheduleTimers(remaining);
 		return clearTimers;
 	}, [clearTimers, logout, onExpired, scheduleTimers]);
-	
-	return { logout, extendSession };
 
+	return { logout, extendSession };
 }


### PR DESCRIPTION
Added session timeout warning modal

Warns admin users 2 minutes before their JWT session (1 hour expiration time) expires with a countdown modal. Users can extend their session by 1 hour or logout immediately. 

- Added POST /user/refresh endpoint to issue a fresh JWT without re-login

Closes #890 