### PR TITLE
Automate Applications for Organizers

### DIFF
--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -1,3 +1,5 @@
+import random
+
 from datetime import date, datetime
 from logging import getLogger
 from typing import Annotated, Any, Literal, Mapping, Optional, Union
@@ -199,8 +201,49 @@ class DeleteNotesRequest(BaseModel):
     review_index: int
 
 
+class ReviewAssignmentsResponse(BaseModel):
+    applicant_ids: list[str]
+    target_count: int
+
+
 class WaiverStatusRequest(BaseModel):
     is_signed: bool
+
+
+REVIEW_ASSIGNMENT_BATCH_SIZE = 10
+
+
+def _reviewer_has_reviewed(record: Mapping[str, Any], reviewer_uid: str) -> bool:
+    application_data = record.get("application_data", {})
+    if not isinstance(application_data, Mapping):
+        return False
+
+    reviews = application_data.get("reviews", [])
+    return any(review[1] == reviewer_uid for review in reviews)
+
+
+def _unique_reviewers(record: Mapping[str, Any]) -> set[str]:
+    application_data = record.get("application_data", {})
+    if not isinstance(application_data, Mapping):
+        return set()
+
+    reviews = application_data.get("reviews", [])
+    return {review[1] for review in reviews}
+
+
+def _assigned_reviewers(record: Mapping[str, Any]) -> list[str]:
+    assigned_reviewers = record.get("assigned_reviewers", [])
+    return assigned_reviewers if isinstance(assigned_reviewers, list) else []
+
+
+def _is_review_assignable(record: Mapping[str, Any], reviewer_uid: str) -> bool:
+    if record.get("status") == Decision.VOIDED:
+        return False
+    if reviewer_uid in _unique_reviewers(record):
+        return False
+    if len(_unique_reviewers(record)) >= 2:
+        return False
+    return len(_assigned_reviewers(record)) < 2
 
 
 async def mentor_volunteer_applicants(
@@ -306,6 +349,65 @@ async def hacker_applicants(
         return TypeAdapter(list[HackerApplicantSummary]).validate_python(records)
     except ValidationError:
         raise RuntimeError("Could not parse applicant data.")
+
+
+@router.get("/review-assignments/hackers")
+async def hacker_review_assignments(
+    user: Annotated[User, Depends(require_hacker_reviewer)],
+) -> ReviewAssignmentsResponse:
+    """Get or create the current reviewer's hacker application assignments."""
+    records: list[dict[str, object]] = await mongodb_handler.retrieve(
+        Collection.USERS,
+        {"roles": Role.HACKER},
+        [
+            "_id",
+            "status",
+            "application_data.reviews",
+            "application_data.submission_time",
+            "assigned_reviewers",
+        ],
+        sort=[("application_data.submission_time", DESCENDING)],
+    )
+
+    active_assignments = [
+        str(record["_id"])
+        for record in records
+        if user.uid in _assigned_reviewers(record)
+        and not _reviewer_has_reviewed(record, user.uid)
+        and record.get("status") != Decision.VOIDED
+        and len(_unique_reviewers(record)) < 2
+    ]
+
+    needed_assignments = REVIEW_ASSIGNMENT_BATCH_SIZE - len(active_assignments)
+    if needed_assignments <= 0:
+        return ReviewAssignmentsResponse(
+            applicant_ids=active_assignments,
+            target_count=REVIEW_ASSIGNMENT_BATCH_SIZE,
+        )
+
+    candidates = [
+        record
+        for record in records
+        if str(record["_id"]) not in active_assignments
+        and user.uid not in _assigned_reviewers(record)
+        and _is_review_assignable(record, user.uid)
+    ]
+    random.shuffle(candidates)
+    candidates.sort(key=lambda record: len(_assigned_reviewers(record)))
+
+    new_assignments = candidates[:needed_assignments]
+    for record in new_assignments:
+        await mongodb_handler.raw_update_one(
+            Collection.USERS,
+            {"_id": record["_id"]},
+            {"$addToSet": {"assigned_reviewers": user.uid}},
+        )
+
+    return ReviewAssignmentsResponse(
+        applicant_ids=active_assignments
+        + [str(record["_id"]) for record in new_assignments],
+        target_count=REVIEW_ASSIGNMENT_BATCH_SIZE,
+    )
 
 
 async def _user_has_role(uid: str, role: Role) -> bool:

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -381,7 +381,9 @@ async def hacker_review_assignments(
         and record.get("status") != Decision.VOIDED
         and len(_unique_reviewers(record)) < 2
     ]
-    overflow_assignment_records = active_assignment_records[REVIEW_ASSIGNMENT_BATCH_SIZE:]
+    overflow_assignment_records = active_assignment_records[
+        REVIEW_ASSIGNMENT_BATCH_SIZE:
+    ]
     for record in overflow_assignment_records:
         await mongodb_handler.raw_update_one(
             Collection.USERS,

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -204,6 +204,7 @@ class DeleteNotesRequest(BaseModel):
 class ReviewAssignmentsResponse(BaseModel):
     applicant_ids: list[str]
     target_count: int
+    completed_count: int
 
 
 class WaiverStatusRequest(BaseModel):
@@ -368,21 +369,35 @@ async def hacker_review_assignments(
         ],
         sort=[("application_data.submission_time", DESCENDING)],
     )
+    completed_assignments = sum(
+        1 for record in records if _reviewer_has_reviewed(record, user.uid)
+    )
 
-    active_assignments = [
-        str(record["_id"])
+    active_assignment_records = [
+        record
         for record in records
         if user.uid in _assigned_reviewers(record)
         and not _reviewer_has_reviewed(record, user.uid)
         and record.get("status") != Decision.VOIDED
         and len(_unique_reviewers(record)) < 2
     ]
+    overflow_assignment_records = active_assignment_records[REVIEW_ASSIGNMENT_BATCH_SIZE:]
+    for record in overflow_assignment_records:
+        await mongodb_handler.raw_update_one(
+            Collection.USERS,
+            {"_id": record["_id"]},
+            {"$pull": {"assigned_reviewers": user.uid}},
+        )
+
+    active_assignment_records = active_assignment_records[:REVIEW_ASSIGNMENT_BATCH_SIZE]
+    active_assignments = [str(record["_id"]) for record in active_assignment_records]
 
     needed_assignments = REVIEW_ASSIGNMENT_BATCH_SIZE - len(active_assignments)
     if needed_assignments <= 0:
         return ReviewAssignmentsResponse(
             applicant_ids=active_assignments,
             target_count=REVIEW_ASSIGNMENT_BATCH_SIZE,
+            completed_count=completed_assignments,
         )
 
     candidates = [
@@ -407,6 +422,7 @@ async def hacker_review_assignments(
         applicant_ids=active_assignments
         + [str(record["_id"]) for record in new_assignments],
         target_count=REVIEW_ASSIGNMENT_BATCH_SIZE,
+        completed_count=completed_assignments,
     )
 
 

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -182,6 +182,41 @@ def test_hacker_review_assignments_keep_active_assignments(
 
 
 @patch("services.mongodb_handler.raw_update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_hacker_review_assignments_caps_active_assignments(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_retrieve: AsyncMock,
+    mock_mongodb_handler_raw_update_one: AsyncMock,
+) -> None:
+    mock_mongodb_handler_retrieve_one.return_value = HACKER_REVIEWER_IDENTITY
+    mock_mongodb_handler_retrieve.return_value = [
+        {
+            "_id": f"edu.uci.assigned{i}",
+            "status": "PENDING",
+            "application_data": {
+                "reviews": [],
+                "submission_time": datetime(2026, 1, i + 1),
+            },
+            "assigned_reviewers": ["edu.uci.alicia"],
+        }
+        for i in range(12)
+    ]
+
+    res = reviewer_client.get("/review-assignments/hackers")
+
+    assert res.status_code == 200
+    assert len(res.json()["applicant_ids"]) == 10
+    assert mock_mongodb_handler_raw_update_one.await_count == 2
+    first_update = mock_mongodb_handler_raw_update_one.await_args_list[0]
+    assert first_update.args == (
+        Collection.USERS,
+        {"_id": "edu.uci.assigned10"},
+        {"$pull": {"assigned_reviewers": "edu.uci.alicia"}},
+    )
+
+
+@patch("services.mongodb_handler.raw_update_one", autospec=True)
 @patch("services.mongodb_handler.retrieve_one", autospec=True)
 def test_can_submit_nonhacker_review(
     mock_mongodb_handler_retrieve_one: AsyncMock,

--- a/apps/api/tests/test_admin.py
+++ b/apps/api/tests/test_admin.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any
-from unittest.mock import ANY, AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI, HTTPException
@@ -91,6 +91,94 @@ def test_cannot_retrieve_applicants_without_role(
 
     assert res.status_code == 403
     mock_mongodb_handler_retrieve.assert_not_awaited()
+
+
+@patch("services.mongodb_handler.raw_update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+@patch("routers.admin.random.shuffle", autospec=True)
+def test_hacker_review_assignments_are_created(
+    mock_shuffle: MagicMock,
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_retrieve: AsyncMock,
+    mock_mongodb_handler_raw_update_one: AsyncMock,
+) -> None:
+    mock_shuffle.side_effect = lambda records: records.reverse()
+    mock_mongodb_handler_retrieve_one.return_value = HACKER_REVIEWER_IDENTITY
+    mock_mongodb_handler_retrieve.return_value = [
+        {
+            "_id": "edu.uci.applicant1",
+            "status": "PENDING",
+            "application_data": {
+                "reviews": [],
+                "submission_time": datetime(2026, 1, 1),
+            },
+            "assigned_reviewers": [],
+        },
+        {
+            "_id": "edu.uci.applicant2",
+            "status": "PENDING",
+            "application_data": {
+                "reviews": [],
+                "submission_time": datetime(2026, 1, 2),
+            },
+            "assigned_reviewers": [],
+        },
+    ]
+
+    res = reviewer_client.get("/review-assignments/hackers")
+
+    assert res.status_code == 200
+    assert res.json()["applicant_ids"] == [
+        "edu.uci.applicant2",
+        "edu.uci.applicant1",
+    ]
+    assert res.json()["target_count"] == 10
+    mock_shuffle.assert_called_once()
+    assert mock_mongodb_handler_raw_update_one.await_count == 2
+    first_update = mock_mongodb_handler_raw_update_one.await_args_list[0]
+    assert first_update.args == (
+        Collection.USERS,
+        {"_id": "edu.uci.applicant2"},
+        {"$addToSet": {"assigned_reviewers": "edu.uci.alicia"}},
+    )
+
+
+@patch("services.mongodb_handler.raw_update_one", autospec=True)
+@patch("services.mongodb_handler.retrieve", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_hacker_review_assignments_keep_active_assignments(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_mongodb_handler_retrieve: AsyncMock,
+    mock_mongodb_handler_raw_update_one: AsyncMock,
+) -> None:
+    mock_mongodb_handler_retrieve_one.return_value = HACKER_REVIEWER_IDENTITY
+    mock_mongodb_handler_retrieve.return_value = [
+        {
+            "_id": "edu.uci.assigned",
+            "status": "PENDING",
+            "application_data": {
+                "reviews": [],
+                "submission_time": datetime(2026, 1, 1),
+            },
+            "assigned_reviewers": ["edu.uci.alicia"],
+        },
+        {
+            "_id": "edu.uci.reviewed",
+            "status": "REVIEWED",
+            "application_data": {
+                "reviews": [[datetime(2026, 1, 2), "edu.uci.alicia", 10, None]],
+                "submission_time": datetime(2026, 1, 2),
+            },
+            "assigned_reviewers": ["edu.uci.alicia"],
+        },
+    ]
+
+    res = reviewer_client.get("/review-assignments/hackers")
+
+    assert res.status_code == 200
+    assert res.json()["applicant_ids"] == ["edu.uci.assigned"]
+    mock_mongodb_handler_raw_update_one.assert_not_awaited()
 
 
 @patch("services.mongodb_handler.raw_update_one", autospec=True)

--- a/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantFilters.tsx
@@ -123,7 +123,7 @@ function ApplicantFilters({
 				placeholder="Choose reviews"
 				selectedAriaLabel="Selected"
 			/>
-			{applicantType === ParticipantRole.Hacker && (
+			{applicantType === ParticipantRole.Hacker && setUCINetIDFilter && (
 				<Multiselect
 					selectedOptions={uciNetIDFilter ?? []}
 					onChange={({ detail }) => setUCINetIDFilter?.(detail.selectedOptions)}

--- a/apps/site/src/app/admin/applicants/components/ApplicantNavigationButtons.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantNavigationButtons.tsx
@@ -26,8 +26,6 @@ function ApplicantNavigationButtons({
 	const { assignedApplicantIds, loading: assignmentsLoading } =
 		useHackerReviewAssignments(useAssignedQueue);
 
-	if (loading || assignmentsLoading || applicantList.length === 0) return null;
-
 	const navigationList = useMemo(() => {
 		if (!useAssignedQueue) return applicantList;
 
@@ -39,6 +37,8 @@ function ApplicantNavigationButtons({
 			return applicant ? [applicant] : [];
 		});
 	}, [applicantList, assignedApplicantIds, useAssignedQueue]);
+
+	if (loading || assignmentsLoading || applicantList.length === 0) return null;
 
 	if (navigationList.length === 0) return null;
 

--- a/apps/site/src/app/admin/applicants/components/ApplicantNavigationButtons.tsx
+++ b/apps/site/src/app/admin/applicants/components/ApplicantNavigationButtons.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { useContext, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@cloudscape-design/components/button";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 
+import UserContext from "@/lib/admin/UserContext";
+import { isDirector } from "@/lib/admin/authorization";
 import useHackerApplicants from "@/lib/admin/useHackerApplicants";
+import useHackerReviewAssignments from "@/lib/admin/useHackerReviewAssignments";
 
 interface ApplicantNavigationButtonsProps {
 	uid: string;
@@ -16,34 +20,37 @@ function ApplicantNavigationButtons({
 	basePath,
 }: ApplicantNavigationButtonsProps) {
 	const router = useRouter();
+	const { roles } = useContext(UserContext);
+	const useAssignedQueue = !isDirector(roles);
 	const { applicantList, loading } = useHackerApplicants();
+	const { assignedApplicantIds, loading: assignmentsLoading } =
+		useHackerReviewAssignments(useAssignedQueue);
 
-	if (loading || applicantList.length === 0) return null;
+	if (loading || assignmentsLoading || applicantList.length === 0) return null;
 
-	const currentIndex = applicantList.findIndex((a) => a._id === uid);
+	const navigationList = useMemo(() => {
+		if (!useAssignedQueue) return applicantList;
+
+		const applicantById = new Map(
+			applicantList.map((applicant) => [applicant._id, applicant]),
+		);
+		return assignedApplicantIds.flatMap((applicantId) => {
+			const applicant = applicantById.get(applicantId);
+			return applicant ? [applicant] : [];
+		});
+	}, [applicantList, assignedApplicantIds, useAssignedQueue]);
+
+	if (navigationList.length === 0) return null;
+
+	const currentIndex = navigationList.findIndex((a) => a._id === uid);
 
 	const prevApplicant =
-		currentIndex > 0 ? applicantList[currentIndex - 1] : null;
+		currentIndex > 0 ? navigationList[currentIndex - 1] : null;
 
 	const nextApplicant =
-		currentIndex < applicantList.length - 1
-			? applicantList[currentIndex + 1]
+		currentIndex !== -1 && currentIndex < navigationList.length - 1
+			? navigationList[currentIndex + 1]
 			: null;
-
-	const unreviewedApplicants = applicantList.filter(
-		(a) => (a.reviewers?.length ?? 0) < 2,
-	);
-
-	const nextUnreviewed =
-		applicantList
-			.slice(currentIndex + 1)
-			.find((a) => (a.reviewers?.length ?? 0) < 2) ?? unreviewedApplicants[0];
-
-	const allReviewed = unreviewedApplicants.length === 0;
-
-	const lastUnreviewed =
-		!allReviewed &&
-		unreviewedApplicants[unreviewedApplicants.length - 1]._id === uid;
 
 	return (
 		<SpaceBetween direction="horizontal" size="xs">
@@ -62,14 +69,6 @@ function ApplicantNavigationButtons({
 				}
 			>
 				Next
-			</Button>
-			<Button
-				disabled={allReviewed || lastUnreviewed}
-				onClick={() =>
-					nextUnreviewed && router.push(`${basePath}/${nextUnreviewed._id}`)
-				}
-			>
-				Next Unreviewed
 			</Button>
 		</SpaceBetween>
 	);

--- a/apps/site/src/app/admin/applicants/components/DetailedScoreApplicant.tsx
+++ b/apps/site/src/app/admin/applicants/components/DetailedScoreApplicant.tsx
@@ -12,6 +12,7 @@ import useApplicant, {
 } from "@/lib/admin/useApplicant";
 
 import ApplicantOverview from "./ApplicantOverview";
+import ApplicantNavigationButtons from "./ApplicantNavigationButtons";
 import { ParticipantRole } from "@/lib/userRecord";
 import { ScoredFields } from "@/lib/detailedScores";
 import ZotHacksHackerApplication from "../zothacks-hackers/components/ZotHacksHackerApplication";
@@ -90,6 +91,10 @@ function DetailedScoreApplicant({
 									status={applicant.status}
 									onVoid={voidApplicant}
 								/>
+								<ApplicantNavigationButtons
+									uid={uid}
+									basePath="/admin/applicants/zothacks-hackers"
+								/>
 								<HackerApplicantActions
 									applicant={applicant._id}
 									reviews={application_data.reviews}
@@ -156,6 +161,10 @@ function DetailedScoreApplicant({
 					scores={scores}
 					notes={notes}
 					onSubmitDetailedReview={handleSubmitDetailedReview}
+				/>
+				<ApplicantNavigationButtons
+					uid={uid}
+					basePath="/admin/applicants/zothacks-hackers"
 				/>
 			</div>
 		</ContentLayout>

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantActions.tsx
@@ -74,12 +74,29 @@ function HackerApplicantActions({
 		canReview || (isUserDirector && hasDirectorPreviousExperienceReview);
 
 	const handleClick = () => {
-		const hasMissingFields = [
-			"previous_experience",
+		const hasIrvineHacksScoring = [
 			"frq_change",
 			"frq_ambition",
 			"frq_character",
-		].some((field) => !(field in scores));
+		].some((field) => field in scores);
+		const hasZotHacksScoring = [
+			"elevator_pitch_saq",
+			"tech_experience_saq",
+			"learn_about_self_saq",
+			"pixel_art_saq",
+		].some((field) => field in scores);
+		const hasMissingFields =
+			(hasIrvineHacksScoring &&
+				["frq_change", "frq_ambition", "frq_character"].some(
+					(field) => !(field in scores),
+				)) ||
+			(hasZotHacksScoring &&
+				[
+					"elevator_pitch_saq",
+					"tech_experience_saq",
+					"learn_about_self_saq",
+					"pixel_art_saq",
+				].some((field) => !(field in scores)));
 
 		if (hasMissingFields) {
 			const msgId = `missing-fields-${Date.now()}`;

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
@@ -78,6 +78,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 	const {
 		assignedApplicantIds,
 		targetCount,
+		completedCount,
 		loading: assignmentsLoading,
 	} = useHackerReviewAssignments(!isUserDirector);
 	const reviewableApplicantList = useMemo(() => {
@@ -363,8 +364,8 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 					setSelectedStatuses={setSelectedStatuses}
 					selectedDecisions={selectedDecisions}
 					setSelectedDecisions={setSelectedDecisions}
-					uciNetIDFilter={uciNetIDFilter}
-					setUCINetIDFilter={setUCINetIDFilter}
+					uciNetIDFilter={isUserDirector ? uciNetIDFilter : undefined}
+					setUCINetIDFilter={isUserDirector ? setUCINetIDFilter : undefined}
 					applicantType={ParticipantRole.Hacker}
 					sortOption={sortOption}
 					setSortOption={isUserDirector ? setSortOption : undefined}
@@ -385,6 +386,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 							>
 								Showing your assigned review queue
 								{targetCount ? ` (${items.length}/${targetCount})` : ""}
+								{completedCount ? `, ${completedCount} reviewed` : ""}
 							</div>
 						)}
 						<div

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
@@ -37,6 +37,7 @@ import useAvgScoreSetting from "@/lib/admin/useAvgScoreSetting";
 import useHackerApplicants, {
 	HackerApplicantSummary,
 } from "@/lib/admin/useHackerApplicants";
+import useHackerReviewAssignments from "@/lib/admin/useHackerReviewAssignments";
 import { uidToPseudonym } from "@/lib/admin/anonymize";
 import { ParticipantRole, Status } from "@/lib/userRecord";
 import { OVERQUALIFIED_SCORE } from "@/lib/decisionScores";
@@ -74,6 +75,22 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 
 	const { applicantList, loading, approveDuplicateName } =
 		useHackerApplicants();
+	const {
+		assignedApplicantIds,
+		targetCount,
+		loading: assignmentsLoading,
+	} = useHackerReviewAssignments(!isUserDirector);
+	const reviewableApplicantList = useMemo(() => {
+		if (isUserDirector) return applicantList;
+
+		const applicantById = new Map(
+			applicantList.map((applicant) => [applicant._id, applicant]),
+		);
+		return assignedApplicantIds.flatMap((applicantId) => {
+			const applicant = applicantById.get(applicantId);
+			return applicant ? [applicant] : [];
+		});
+	}, [applicantList, assignedApplicantIds, isUserDirector]);
 
 	const selectedStatusValues = selectedStatuses.map(({ value }) => value);
 	const selectedDecisionValues = selectedDecisions.map(({ value }) => value);
@@ -98,7 +115,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 		}
 	}, [top400]);
 
-	const filteredApplicants = applicantList.filter((applicant) => {
+	const filteredApplicants = reviewableApplicantList.filter((applicant) => {
 		if (
 			selectedStatusValues.includes(Status.Pending) &&
 			applicant.avg_score === OVERQUALIFIED_SCORE
@@ -134,7 +151,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 		);
 	});
 
-	const filteredApplicants400 = [...applicantList]
+	const filteredApplicants400 = [...reviewableApplicantList]
 		.filter(
 			(applicant) =>
 				applicant.director_previous_experience_reviewed &&
@@ -170,6 +187,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 
 	const baseItems = top400 ? filteredApplicants400 : filteredApplicants;
 	const items = useMemo(() => {
+		if (!isUserDirector) return baseItems;
 		if (!sortOption?.value) return baseItems;
 		return [...baseItems].sort((a, b) => {
 			switch (sortOption.value) {
@@ -191,14 +209,14 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 					return 0;
 			}
 		});
-	}, [baseItems, sortOption]);
+	}, [baseItems, isUserDirector, sortOption]);
 
 	const counter =
 		selectedStatuses.length > 0 ||
 		selectedDecisions.length > 0 ||
 		uciNetIDFilter.length > 0
-			? `(${items.length}/${applicantList.length})`
-			: `(${applicantList.length})`;
+			? `(${items.length}/${reviewableApplicantList.length})`
+			: `(${reviewableApplicantList.length})`;
 
 	const emptyContent = (
 		<Box textAlign="center" color="inherit">
@@ -233,10 +251,13 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 		content: DirectorPreviousExperienceReviewedStatus,
 	};
 	const duplicateNames = useMemo(() => {
+		if (!isUserDirector) return new Set<string>();
+
 		const nameCounts = new Map<string, number>();
 
 		for (const { first_name, last_name } of applicantList) {
 			const name = `${first_name} ${last_name}`.trim().toLowerCase();
+			if (!name) continue;
 			nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
 		}
 
@@ -245,7 +266,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 				.filter(([, count]) => count > 1)
 				.map(([name]) => name),
 		);
-	}, [applicantList]);
+	}, [applicantList, isUserDirector]);
 
 	const renderHeader = useCallback(
 		({
@@ -266,9 +287,10 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 					director_previous_experience_reviewed
 				}
 				isDirector={isUserDirector}
-				isDuplicate={duplicateNames.has(
-					`${first_name} ${last_name}`.trim().toLowerCase(),
-				)}
+				isDuplicate={
+					isUserDirector &&
+					duplicateNames.has(`${first_name} ${last_name}`.trim().toLowerCase())
+				}
 				duplicateNameApproved={duplicate_name_approved}
 				onApproveDuplicate={(approved) => approveDuplicateName(_id, approved)}
 			/>
@@ -330,7 +352,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 					},
 				],
 			}}
-			loading={loading}
+			loading={loading || assignmentsLoading}
 			loadingText="Loading applicants"
 			items={items}
 			trackBy="_id"
@@ -345,7 +367,7 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 					setUCINetIDFilter={setUCINetIDFilter}
 					applicantType={ParticipantRole.Hacker}
 					sortOption={sortOption}
-					setSortOption={setSortOption}
+					setSortOption={isUserDirector ? setSortOption : undefined}
 				/>
 			}
 			empty={emptyContent}
@@ -353,6 +375,18 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 				<div>
 					<Header actions={isUserDirector && <HackerThresholdInputs />}>
 						Hacker Applicants {counter}
+						{!isUserDirector && (
+							<div
+								style={{
+									fontSize: "0.875rem",
+									color: "#5f6b7a",
+									marginTop: "4px",
+								}}
+							>
+								Showing your assigned review queue
+								{targetCount ? ` (${items.length}/${targetCount})` : ""}
+							</div>
+						)}
 						<div
 							style={{
 								fontSize: "0.875rem",

--- a/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
+++ b/apps/site/src/app/admin/applicants/components/HackerApplicantsList.tsx
@@ -359,17 +359,19 @@ function HackerApplicantsList({ hackathonName }: HackerApplicantsListProps) {
 			trackBy="_id"
 			variant="full-page"
 			filter={
-				<ApplicantFilters
-					selectedStatuses={selectedStatuses}
-					setSelectedStatuses={setSelectedStatuses}
-					selectedDecisions={selectedDecisions}
-					setSelectedDecisions={setSelectedDecisions}
-					uciNetIDFilter={isUserDirector ? uciNetIDFilter : undefined}
-					setUCINetIDFilter={isUserDirector ? setUCINetIDFilter : undefined}
-					applicantType={ParticipantRole.Hacker}
-					sortOption={sortOption}
-					setSortOption={isUserDirector ? setSortOption : undefined}
-				/>
+				isUserDirector ? (
+					<ApplicantFilters
+						selectedStatuses={selectedStatuses}
+						setSelectedStatuses={setSelectedStatuses}
+						selectedDecisions={selectedDecisions}
+						setSelectedDecisions={setSelectedDecisions}
+						uciNetIDFilter={uciNetIDFilter}
+						setUCINetIDFilter={setUCINetIDFilter}
+						applicantType={ParticipantRole.Hacker}
+						sortOption={sortOption}
+						setSortOption={setSortOption}
+					/>
+				) : null
 			}
 			empty={emptyContent}
 			header={

--- a/apps/site/src/lib/admin/useHackerReviewAssignments.ts
+++ b/apps/site/src/lib/admin/useHackerReviewAssignments.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import useSWR from "swr";
+
+interface HackerReviewAssignmentsResponse {
+	applicant_ids: string[];
+	target_count: number;
+}
+
+const HACKER_REVIEW_ASSIGNMENTS_ROUTE = "/api/admin/review-assignments/hackers";
+
+const fetcher = async (url: string) => {
+	const res = await axios.get<HackerReviewAssignmentsResponse>(url);
+	return res.data;
+};
+
+function useHackerReviewAssignments(enabled = true) {
+	const { data, error, isLoading, mutate } =
+		useSWR<HackerReviewAssignmentsResponse>(
+			enabled ? HACKER_REVIEW_ASSIGNMENTS_ROUTE : null,
+			fetcher,
+		);
+
+	return {
+		assignedApplicantIds: data?.applicant_ids ?? [],
+		targetCount: data?.target_count ?? 0,
+		loading: enabled && isLoading,
+		error,
+		mutate,
+	};
+}
+
+export default useHackerReviewAssignments;

--- a/apps/site/src/lib/admin/useHackerReviewAssignments.ts
+++ b/apps/site/src/lib/admin/useHackerReviewAssignments.ts
@@ -4,6 +4,7 @@ import useSWR from "swr";
 interface HackerReviewAssignmentsResponse {
 	applicant_ids: string[];
 	target_count: number;
+	completed_count: number;
 }
 
 const HACKER_REVIEW_ASSIGNMENTS_ROUTE = "/api/admin/review-assignments/hackers";
@@ -23,6 +24,7 @@ function useHackerReviewAssignments(enabled = true) {
 	return {
 		assignedApplicantIds: data?.applicant_ids ?? [],
 		targetCount: data?.target_count ?? 0,
+		completedCount: data?.completed_count ?? 0,
 		loading: enabled && isLoading,
 		error,
 		mutate,


### PR DESCRIPTION
## Flow
- organizer logs in and gets randomly assigned a batch of 10 applications to review
- after they've been reviewed, a new applicant gets added to their "batch"
- if there are no applications to review, there are no applications displayed to the organizer

## Other notes
- removed the sort dropdown for organizers
- removed Next Unreviewed button with just next and prev for simplicity
- excludes applicants that are voided, already reviewed, or already reviewed by that organizer from their batch pool
- directors don't get assigned any applicants to review (not sure if we want this but i think it kinda makes sense)

Closes #858 