### PR TITLE
feat: add Google Wallet check-in pass endpoint

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -25,7 +25,7 @@ For deployment, the following environment variables need to be set:
 - `MENTOR_RESUMES_FOLDER_ID`, the ID of the Google Drive folder to upload mentor resumes to
 - Either `SERVICE_ACCOUNT_FILE` or `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`: We use a Google service acccount in tandem with aiogoogle to automatically upload resumes when submitting a form. The keys are JSON that can either be stored in a file, in which case the path of the file should be stored in `SERVICE_ACCOUNT_FILE`, or be stored directly in `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`. For local development, it is recommended to take the `SERVICE_ACCOUNT_FILE` approach.
 - `DOCUSIGN_HMAC_KEY`, the shared HMAC key for validating DocuSign Connect webhook event payloads. Both IrvineHacks and ZotHacks DocuSign Connect configurations should use this same value; the API distinguishes hackathons by PowerForm ID.
-- Either `WALLET_SERVICE_ACCOUNT_FILE` or `GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS`: A Google service account key JSON used to sign "Add to Google Wallet" pass JWTs for the ZotHacks check-in pass. This service account must be granted access in the Google Wallet Business Console for the relevant issuer, so it is kept separate from the Drive service account above. Follows the same file-vs-inline-JSON convention as `SERVICE_ACCOUNT_FILE`/`GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`.
+- `GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS`: A Google service account key JSON used to sign "Add to Google Wallet" pass JWTs for the ZotHacks check-in pass. This service account must be granted access in the Google Wallet Business Console for the relevant issuer, so it is kept separate from the Drive service account above.
 
 For staging, the following environment variables should also bet set:
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -25,6 +25,7 @@ For deployment, the following environment variables need to be set:
 - `MENTOR_RESUMES_FOLDER_ID`, the ID of the Google Drive folder to upload mentor resumes to
 - Either `SERVICE_ACCOUNT_FILE` or `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`: We use a Google service acccount in tandem with aiogoogle to automatically upload resumes when submitting a form. The keys are JSON that can either be stored in a file, in which case the path of the file should be stored in `SERVICE_ACCOUNT_FILE`, or be stored directly in `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`. For local development, it is recommended to take the `SERVICE_ACCOUNT_FILE` approach.
 - `DOCUSIGN_HMAC_KEY`, the shared HMAC key for validating DocuSign Connect webhook event payloads. Both IrvineHacks and ZotHacks DocuSign Connect configurations should use this same value; the API distinguishes hackathons by PowerForm ID.
+- Either `WALLET_SERVICE_ACCOUNT_FILE` or `GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS`: A Google service account key JSON used to sign "Add to Google Wallet" pass JWTs for the ZotHacks check-in pass. This service account must be granted access in the Google Wallet Business Console for the relevant issuer, so it is kept separate from the Drive service account above. Follows the same file-vs-inline-JSON convention as `SERVICE_ACCOUNT_FILE`/`GOOGLE_SERVICE_ACCOUNT_CREDENTIALS`.
 
 For staging, the following environment variables should also bet set:
 

--- a/apps/api/src/routers/user.py
+++ b/apps/api/src/routers/user.py
@@ -35,10 +35,11 @@ from models.ApplicationData import (
 )
 from models.user_record import Applicant, BareApplicant, Role, Status
 from models.ApplicationData import Decision
-from services import docusign_handler, mongodb_handler
+from services import docusign_handler, google_wallet_handler, mongodb_handler
 from services.docusign_handler import WebhookPayload
 from services.mongodb_handler import Collection
 from utils import email_handler, resume_handler
+from utils.hackathon_context import HackathonName, hackathon_name_ctx
 
 log = getLogger(__name__)
 
@@ -78,6 +79,10 @@ class WaitlistStatus(BaseModel):
 
 class ApplicationData(BaseModel):
     application_data: Union[CharacterIndexes, None] = None
+
+
+class WalletPassResponse(BaseModel):
+    save_url: str
 
 
 def _is_past_deadline(now: datetime) -> bool:
@@ -725,6 +730,36 @@ async def rsvp_late_arrival(
         log.info(f"User {user.uid} set arrival_time to {arrival_value}.")
 
     return RedirectResponse("/portal", status.HTTP_303_SEE_OTHER)
+
+
+@router.get("/wallet/pass")
+async def wallet_checkin_pass(
+    user: Annotated[User, Depends(require_user_identity)],
+) -> WalletPassResponse:
+    """Provide an 'Add to Google Wallet' save URL for the ZotHacks
+    applicant check-in pass; the barcode encodes the user's uid."""
+    if hackathon_name_ctx.get() != HackathonName.ZOTHACKS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Wallet check-in passes are only available for ZotHacks.",
+        )
+
+    user_record = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": user.uid}, ["first_name", "last_name"]
+    )
+    full_name = None
+    if user_record and user_record.get("first_name") and user_record.get("last_name"):
+        full_name = f"{user_record['first_name']} {user_record['last_name']}"
+
+    try:
+        save_url = google_wallet_handler.build_checkin_pass_save_url(
+            user.uid, full_name
+        )
+    except Exception:
+        log.exception("Could not build Google Wallet pass for %s.", user.uid)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return WalletPassResponse(save_url=save_url)
 
 
 def _parsed_form(form: FormData) -> dict[str, Any]:

--- a/apps/api/src/services/google_wallet_handler.py
+++ b/apps/api/src/services/google_wallet_handler.py
@@ -31,13 +31,9 @@ _UID_HASH_LENGTH = 10
 
 def _get_service_account() -> dict[str, Any]:
     """Get the Wallet-authorized service account key used to sign pass JWTs."""
-    service_account_file = os.getenv("WALLET_SERVICE_ACCOUNT_FILE")
     service_account_credentials = os.getenv("GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS")
 
-    if service_account_file:
-        with open(service_account_file) as f:
-            return cast(dict[str, Any], json.load(f))
-    elif service_account_credentials:
+    if service_account_credentials:
         service_account_credentials = service_account_credentials.replace("\n", "\\n")
         return cast(dict[str, Any], json.loads(service_account_credentials))
     else:

--- a/apps/api/src/services/google_wallet_handler.py
+++ b/apps/api/src/services/google_wallet_handler.py
@@ -1,0 +1,93 @@
+import hashlib
+import json
+import os
+import re
+import time
+from typing import Any, Optional, cast
+
+from jose import jwt
+
+SAVE_URL_BASE = "https://pay.google.com/gp/v/save/"
+
+GENERIC_CLASS_ID = "3388000000023162467.zothacks-2026"
+ISSUER_ID = GENERIC_CLASS_ID.split(".")[0]
+
+GENERIC_TYPE = "GENERIC_ENTRY_TICKET"
+CARD_TITLE = "ZotHacks 2026"
+CARD_SUBHEADER = "Check-In Pass"
+DEFAULT_HEADER = "Check-In Pass"
+
+# Google Wallet object identifiers may only contain alphanumeric characters,
+# '.', '_', or '-'. See:
+# https://developers.google.com/wallet/generic/rest/v1/genericobject
+_OBJECT_ID_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+# Number of hex digits of the uid's hash appended to the sanitized suffix.
+# Since sanitization is lossy (distinct uids can sanitize to the same string),
+# this keeps the resulting Wallet object ID unique per uid while remaining
+# deterministic, so re-saving a pass reuses the same object.
+_UID_HASH_LENGTH = 10
+
+
+def _get_service_account() -> dict[str, Any]:
+    """Get the Wallet-authorized service account key used to sign pass JWTs."""
+    service_account_file = os.getenv("WALLET_SERVICE_ACCOUNT_FILE")
+    service_account_credentials = os.getenv("GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS")
+
+    if service_account_file:
+        with open(service_account_file) as f:
+            return cast(dict[str, Any], json.load(f))
+    elif service_account_credentials:
+        service_account_credentials = service_account_credentials.replace("\n", "\\n")
+        return cast(dict[str, Any], json.loads(service_account_credentials))
+    else:
+        raise RuntimeError("Google Wallet service account credentials not found")
+
+
+def _sanitized_object_suffix(uid: str) -> str:
+    """Return a Wallet-legal object ID suffix derived from the given uid.
+
+    Sanitization alone is lossy (e.g. "a+b" and "a_b" both become "a_b"), so
+    a short deterministic hash of the raw uid is appended to keep the
+    resulting suffix unique per uid while remaining stable across calls.
+    """
+    sanitized = _OBJECT_ID_UNSAFE_CHARS.sub("_", uid)
+    uid_hash = hashlib.sha256(uid.encode()).hexdigest()[:_UID_HASH_LENGTH]
+    return f"{sanitized}-{uid_hash}"
+
+
+def _build_generic_object(uid: str, full_name: Optional[str]) -> dict[str, Any]:
+    """Build a Google Wallet genericObject whose barcode encodes the given uid."""
+    header_value = full_name if full_name else DEFAULT_HEADER
+
+    generic_object: dict[str, Any] = {
+        "id": f"{ISSUER_ID}.{_sanitized_object_suffix(uid)}",
+        "classId": GENERIC_CLASS_ID,
+        "genericType": GENERIC_TYPE,
+        "state": "ACTIVE",
+        "cardTitle": {"defaultValue": {"language": "en-US", "value": CARD_TITLE}},
+        "header": {"defaultValue": {"language": "en-US", "value": header_value}},
+        "subheader": {"defaultValue": {"language": "en-US", "value": CARD_SUBHEADER}},
+        "barcode": {"type": "QR_CODE", "value": uid, "alternateText": uid},
+    }
+
+    return generic_object
+
+
+def build_checkin_pass_save_url(uid: str, full_name: Optional[str] = None) -> str:
+    """Build a signed 'Add to Google Wallet' save URL for a ZotHacks check-in
+    pass, encoding the given applicant uid as the barcode value."""
+    service_account = _get_service_account()
+    generic_object = _build_generic_object(uid, full_name)
+
+    claims = {
+        "iss": service_account["client_email"],
+        "aud": "google",
+        "typ": "savetowallet",
+        "iat": int(time.time()),
+        "origins": [],
+        "payload": {"genericObjects": [generic_object]},
+    }
+
+    token = jwt.encode(claims, service_account["private_key"], algorithm="RS256")
+    return f"{SAVE_URL_BASE}{token}"

--- a/apps/api/tests/test_google_wallet_handler.py
+++ b/apps/api/tests/test_google_wallet_handler.py
@@ -1,0 +1,167 @@
+import hashlib
+from typing import Any
+from unittest.mock import Mock, patch
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jose import jwt
+
+from services import google_wallet_handler
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIVATE_KEY_PEM = _PRIVATE_KEY.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.TraditionalOpenSSL,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode()
+_PUBLIC_KEY_PEM = (
+    _PRIVATE_KEY.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode()
+)
+
+SAMPLE_SERVICE_ACCOUNT = {
+    "client_email": "wallet-issuer@example-project.iam.gserviceaccount.com",
+    "private_key": _PRIVATE_KEY_PEM,
+}
+
+
+def _decode_save_url(save_url: str) -> dict[str, Any]:
+    assert save_url.startswith(google_wallet_handler.SAVE_URL_BASE)
+    token = save_url[len(google_wallet_handler.SAVE_URL_BASE) :]
+    return jwt.decode(token, _PUBLIC_KEY_PEM, algorithms=["RS256"], audience="google")
+
+
+def _expected_object_id(uid: str) -> str:
+    """Compute the expected Wallet object ID for the given uid, matching the
+    sanitize-then-hash scheme in `google_wallet_handler._sanitized_object_suffix`."""
+    sanitized = google_wallet_handler._OBJECT_ID_UNSAFE_CHARS.sub("_", uid)
+    uid_hash = hashlib.sha256(uid.encode()).hexdigest()[
+        : google_wallet_handler._UID_HASH_LENGTH
+    ]
+    return f"{google_wallet_handler.ISSUER_ID}.{sanitized}-{uid_hash}"
+
+
+@patch("services.google_wallet_handler._get_service_account", autospec=True)
+def test_build_checkin_pass_save_url_encodes_uid_as_barcode(
+    mock_get_service_account: Mock,
+) -> None:
+    """Test the generated pass barcode encodes the given uid and references
+    the fixed ZotHacks Generic Class."""
+    mock_get_service_account.return_value = SAMPLE_SERVICE_ACCOUNT
+
+    save_url = google_wallet_handler.build_checkin_pass_save_url("edu.uci.hack")
+    claims = _decode_save_url(save_url)
+
+    assert claims["iss"] == SAMPLE_SERVICE_ACCOUNT["client_email"]
+    assert claims["typ"] == "savetowallet"
+
+    generic_objects = claims["payload"]["genericObjects"]
+    assert len(generic_objects) == 1
+
+    generic_object = generic_objects[0]
+    assert generic_object["classId"] == google_wallet_handler.GENERIC_CLASS_ID
+    assert generic_object["genericType"] == "GENERIC_ENTRY_TICKET"
+    assert generic_object["barcode"] == {
+        "type": "QR_CODE",
+        "value": "edu.uci.hack",
+        "alternateText": "edu.uci.hack",
+    }
+    assert generic_object["id"] == _expected_object_id("edu.uci.hack")
+    assert generic_object["cardTitle"]["defaultValue"]["value"] == "ZotHacks 2026"
+    assert generic_object["header"]["defaultValue"]["value"] == "Check-In Pass"
+    assert generic_object["subheader"]["defaultValue"]["value"] == "Check-In Pass"
+
+
+@patch("services.google_wallet_handler._get_service_account", autospec=True)
+def test_build_checkin_pass_save_url_includes_full_name_when_given(
+    mock_get_service_account: Mock,
+) -> None:
+    """Test the pass header is set to the applicant's full name when given,
+    while the subheader keeps identifying the pass type."""
+    mock_get_service_account.return_value = SAMPLE_SERVICE_ACCOUNT
+
+    save_url = google_wallet_handler.build_checkin_pass_save_url(
+        "edu.uci.hack", "Riley Wong"
+    )
+    claims = _decode_save_url(save_url)
+
+    generic_object = claims["payload"]["genericObjects"][0]
+    assert generic_object["header"]["defaultValue"]["value"] == "Riley Wong"
+    assert generic_object["subheader"]["defaultValue"]["value"] == "Check-In Pass"
+
+
+@patch("services.google_wallet_handler._get_service_account", autospec=True)
+def test_build_checkin_pass_save_url_sanitizes_object_id(
+    mock_get_service_account: Mock,
+) -> None:
+    """Test uids with characters illegal in Wallet object IDs are sanitized."""
+    mock_get_service_account.return_value = SAMPLE_SERVICE_ACCOUNT
+
+    save_url = google_wallet_handler.build_checkin_pass_save_url(
+        "guest+tag@example.com"
+    )
+    claims = _decode_save_url(save_url)
+
+    generic_object = claims["payload"]["genericObjects"][0]
+    expected_id = _expected_object_id("guest+tag@example.com")
+    assert generic_object["id"] == expected_id
+    assert generic_object["barcode"]["value"] == "guest+tag@example.com"
+
+
+@patch("services.google_wallet_handler._get_service_account", autospec=True)
+def test_build_checkin_pass_save_url_object_ids_do_not_collide(
+    mock_get_service_account: Mock,
+) -> None:
+    """Test that distinct uids which sanitize to the same string still
+    produce distinct Wallet object IDs."""
+    mock_get_service_account.return_value = SAMPLE_SERVICE_ACCOUNT
+
+    save_url_a = google_wallet_handler.build_checkin_pass_save_url(
+        "guest+a@example.com"
+    )
+    save_url_b = google_wallet_handler.build_checkin_pass_save_url(
+        "guest_a@example.com"
+    )
+
+    generic_object_a = _decode_save_url(save_url_a)["payload"]["genericObjects"][0]
+    generic_object_b = _decode_save_url(save_url_b)["payload"]["genericObjects"][0]
+
+    # Both uids sanitize to "guest_a@example.com" -> "guest_a_example.com", but
+    # since they are different raw uids, the resulting object IDs must differ.
+    assert generic_object_a["id"] != generic_object_b["id"]
+
+
+@patch("services.google_wallet_handler._get_service_account", autospec=True)
+def test_build_checkin_pass_save_url_object_id_is_stable(
+    mock_get_service_account: Mock,
+) -> None:
+    """Test that the same uid always produces the same object ID, so that
+    re-saving a pass updates the same Wallet object instead of creating a new
+    one."""
+    mock_get_service_account.return_value = SAMPLE_SERVICE_ACCOUNT
+
+    save_url_1 = google_wallet_handler.build_checkin_pass_save_url("edu.uci.hack")
+    save_url_2 = google_wallet_handler.build_checkin_pass_save_url("edu.uci.hack")
+
+    generic_object_1 = _decode_save_url(save_url_1)["payload"]["genericObjects"][0]
+    generic_object_2 = _decode_save_url(save_url_2)["payload"]["genericObjects"][0]
+
+    assert generic_object_1["id"] == generic_object_2["id"]
+
+
+def test_missing_credentials_raise_runtime_error(  # type: ignore[no-untyped-def]
+    monkeypatch,
+) -> None:
+    """Test a clear error is raised when no service account is configured."""
+    monkeypatch.delenv("WALLET_SERVICE_ACCOUNT_FILE", raising=False)
+    monkeypatch.delenv("GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS", raising=False)
+
+    try:
+        google_wallet_handler.build_checkin_pass_save_url("edu.uci.hack")
+        assert False, "Expected RuntimeError"
+    except RuntimeError:
+        pass

--- a/apps/api/tests/test_google_wallet_handler.py
+++ b/apps/api/tests/test_google_wallet_handler.py
@@ -157,7 +157,6 @@ def test_missing_credentials_raise_runtime_error(  # type: ignore[no-untyped-def
     monkeypatch,
 ) -> None:
     """Test a clear error is raised when no service account is configured."""
-    monkeypatch.delenv("WALLET_SERVICE_ACCOUNT_FILE", raising=False)
     monkeypatch.delenv("GOOGLE_WALLET_SERVICE_ACCOUNT_CREDENTIALS", raising=False)
 
     try:

--- a/apps/api/tests/test_user_wallet.py
+++ b/apps/api/tests/test_user_wallet.py
@@ -1,0 +1,119 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+from auth.user_identity import GuestUser, UserTestClient
+from middleware.hackathon_context_middleware import HackathonContextMiddleware
+from routers import user
+from services.mongodb_handler import Collection
+from utils.hackathon_context import HackathonName
+
+USER_EMAIL = "tree@stanford.edu"
+USER_UID = "edu.stanford.tree"
+
+app = FastAPI()
+app.include_router(user.router)
+app.add_middleware(HackathonContextMiddleware)
+
+client = TestClient(app, follow_redirects=False)
+
+
+def _zothacks_client() -> TestClient:
+    auth_client = UserTestClient(GuestUser(email=USER_EMAIL), app)
+    auth_client.headers.update({"X-Hackathon-Name": HackathonName.ZOTHACKS})
+    return auth_client
+
+
+def test_wallet_pass_requires_login() -> None:
+    """Test that an unauthenticated request is rejected."""
+    res = client.get(
+        "/wallet/pass", headers={"X-Hackathon-Name": HackathonName.ZOTHACKS}
+    )
+    assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_wallet_pass_requires_zothacks_context() -> None:
+    """Test that the pass is unavailable outside of the ZotHacks context."""
+    auth_client = UserTestClient(GuestUser(email=USER_EMAIL), app)
+    auth_client.headers.update({"X-Hackathon-Name": HackathonName.IRVINEHACKS})
+
+    res = auth_client.get("/wallet/pass")
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@patch("services.google_wallet_handler.build_checkin_pass_save_url", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_wallet_pass_encodes_uid_as_barcode(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_build_checkin_pass_save_url: Mock,
+) -> None:
+    """Test the endpoint asks the handler to encode the user's uid, using
+    their name for personalization when available."""
+    mock_mongodb_handler_retrieve_one.return_value = {
+        "first_name": "Tree",
+        "last_name": "Stanford",
+    }
+    mock_build_checkin_pass_save_url.return_value = (
+        "https://pay.google.com/gp/v/save/signed-jwt"
+    )
+
+    res = _zothacks_client().get("/wallet/pass")
+
+    mock_mongodb_handler_retrieve_one.assert_awaited_once_with(
+        Collection.USERS, {"_id": USER_UID}, ["first_name", "last_name"]
+    )
+    mock_build_checkin_pass_save_url.assert_called_once_with(USER_UID, "Tree Stanford")
+    assert res.status_code == status.HTTP_200_OK
+    assert res.json() == {"save_url": "https://pay.google.com/gp/v/save/signed-jwt"}
+
+
+@patch("services.google_wallet_handler.build_checkin_pass_save_url", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_wallet_pass_without_user_record_omits_name(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_build_checkin_pass_save_url: Mock,
+) -> None:
+    """Test the endpoint still succeeds and passes no name when there is no
+    associated user record yet."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_build_checkin_pass_save_url.return_value = (
+        "https://pay.google.com/gp/v/save/signed-jwt"
+    )
+
+    res = _zothacks_client().get("/wallet/pass")
+
+    mock_build_checkin_pass_save_url.assert_called_once_with(USER_UID, None)
+    assert res.status_code == status.HTTP_200_OK
+
+
+@patch("services.google_wallet_handler.build_checkin_pass_save_url", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_wallet_pass_returns_500_when_credentials_missing(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_build_checkin_pass_save_url: Mock,
+) -> None:
+    """Test that a misconfigured service account surfaces as a 500."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_build_checkin_pass_save_url.side_effect = RuntimeError(
+        "Google Wallet service account credentials not found"
+    )
+
+    res = _zothacks_client().get("/wallet/pass")
+    assert res.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+@patch("services.google_wallet_handler.build_checkin_pass_save_url", autospec=True)
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+def test_wallet_pass_returns_500_on_unexpected_handler_error(
+    mock_mongodb_handler_retrieve_one: AsyncMock,
+    mock_build_checkin_pass_save_url: Mock,
+) -> None:
+    """Test that non-RuntimeError failures from the handler (e.g. malformed
+    credentials or signing errors) are also surfaced as a 500, not a raw
+    unhandled exception."""
+    mock_mongodb_handler_retrieve_one.return_value = None
+    mock_build_checkin_pass_save_url.side_effect = KeyError("private_key")
+
+    res = _zothacks_client().get("/wallet/pass")
+    assert res.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
- adds `GET /user/wallet/pass`, which builds a signed "Add to Google Wallet" save URL for the ZotHacks check-in pass, using the existing Generic Class (`3388000000023162467.zothacks-2026`)
- requires a logged-in user and is scoped to the ZotHacks hackathon context (`X-Hackathon-Name: zothacks`)
- barcode value on the pass is the applicant's `uid`, with the pass header personalized to their name when available
- covered by unit tests for the handler (JWT claims, object id sanitization/collision-safety, stability across re-saves) and the router (auth, hackathon context, success/error responses)

Closes #930